### PR TITLE
More Amily

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,12 +7,15 @@
   <component name="ChangeListManager">
     <list default="true" id="8a292ce1-df00-4848-8a40-d7241dab169d" name="Default" comment="">
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/creature.js" afterPath="$PROJECT_DIR$/js/creature.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/engine/saves.js" afterPath="$PROJECT_DIR$/js/engine/saves.js" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/engine/time.js" afterPath="$PROJECT_DIR$/js/engine/time.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/flags/dataFlags.js" afterPath="$PROJECT_DIR$/js/flags/dataFlags.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/player.js" afterPath="$PROJECT_DIR$/js/player.js" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/pregnancy.js" afterPath="$PROJECT_DIR$/js/pregnancy.js" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/pregnancyProgression.js" afterPath="$PROJECT_DIR$/js/pregnancyProgression.js" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/camp.js" afterPath="$PROJECT_DIR$/js/scenes/camp.js" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/npcs/amily.js" afterPath="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/statusEffectClass.js" afterPath="$PROJECT_DIR$/js/statusEffectClass.js" />
     </list>
     <ignored path="Corruption-of-Champions-HTML.iws" />
     <ignored path=".idea/workspace.xml" />
@@ -33,57 +36,12 @@
   </component>
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-      <file leaf-file-name="amily.js" pinned="false" current-in-tab="true">
+      <file leaf-file-name="amily.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="165">
-              <caret line="32" column="0" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
-              <folding>
-                <element signature="n#!!block;n#Amily#0" expanded="false" />
-                <element signature="e#5241#5455#0" expanded="false" />
-                <element signature="e#5561#5656#0" expanded="false" />
-                <element signature="e#11015#11357#0" expanded="false" />
-                <element signature="e#11415#22544#0" expanded="false" />
-                <element signature="e#43510#51214#0" expanded="false" />
-                <element signature="e#51328#52182#0" expanded="false" />
-                <element signature="e#52340#53102#0" expanded="false" />
-                <element signature="e#53228#53520#0" expanded="false" />
-                <element signature="e#53679#54123#0" expanded="false" />
-                <element signature="e#54228#54734#0" expanded="false" />
-                <element signature="e#55050#55947#0" expanded="false" />
-                <element signature="e#56169#57611#0" expanded="false" />
-                <element signature="e#57728#59553#0" expanded="false" />
-                <element signature="e#59652#61263#0" expanded="false" />
-                <element signature="e#61375#63817#0" expanded="false" />
-                <element signature="e#63953#64534#0" expanded="false" />
-                <element signature="e#64669#66498#0" expanded="false" />
-                <element signature="e#66610#67786#0" expanded="false" />
-                <element signature="e#67896#69305#0" expanded="false" />
-                <element signature="e#69406#70078#0" expanded="false" />
-                <element signature="e#70296#71442#0" expanded="false" />
-                <element signature="e#74519#77538#0" expanded="false" />
-                <element signature="e#77628#79092#0" expanded="false" />
-                <element signature="e#79180#79799#0" expanded="false" />
-                <element signature="e#79885#80612#0" expanded="false" />
-                <element signature="e#80779#100820#0" expanded="false" />
-                <element signature="e#100965#103813#0" expanded="false" />
-                <element signature="e#103913#152802#0" expanded="false" />
-                <element signature="e#152887#159450#0" expanded="false" />
-                <element signature="e#159547#159625#0" expanded="false" />
-                <element signature="e#159797#163535#0" expanded="false" />
-                <element signature="e#163680#166772#0" expanded="false" />
-                <element signature="e#163682#163748#0" expanded="false" />
-                <element signature="e#164068#164522#0" expanded="false" />
-                <element signature="e#164648#166581#0" expanded="false" />
-                <element signature="e#166661#166769#0" expanded="false" />
-                <element signature="e#166886#173321#0" expanded="false" />
-                <element signature="e#238411#239255#0" expanded="false" />
-                <element signature="e#239319#240347#0" expanded="false" />
-                <element signature="e#240411#241076#0" expanded="false" />
-                <element signature="e#241140#243583#0" expanded="false" />
-                <element signature="e#243646#248112#0" expanded="false" />
-                <element signature="e#337569#340622#0" expanded="false" />
-              </folding>
+            <state relative-caret-position="204">
+              <caret line="112" column="4" selection-start-line="112" selection-start-column="4" selection-end-line="112" selection-end-column="4" />
+              <folding />
             </state>
           </provider>
         </entry>
@@ -91,8 +49,8 @@
       <file leaf-file-name="dataFlags.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="281">
-              <caret line="121" column="0" selection-start-line="121" selection-start-column="0" selection-end-line="121" selection-end-column="0" />
+            <state relative-caret-position="56">
+              <caret line="120" column="0" selection-start-line="120" selection-start-column="0" selection-end-line="120" selection-end-column="0" />
               <folding />
             </state>
           </provider>
@@ -101,7 +59,7 @@
       <file leaf-file-name="camp.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="240">
+            <state relative-caret-position="120">
               <caret line="67" column="6" selection-start-line="67" selection-start-column="6" selection-end-line="67" selection-end-column="6" />
               <folding />
             </state>
@@ -111,11 +69,132 @@
       <file leaf-file-name="pregnancyProgression.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="120">
-              <caret line="7" column="0" selection-start-line="7" selection-start-column="0" selection-end-line="7" selection-end-column="0" />
+            <state relative-caret-position="229">
+              <caret line="121" column="49" selection-start-line="121" selection-start-column="49" selection-end-line="121" selection-end-column="49" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="creature.js" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/js/creature.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="94">
+              <caret line="3515" column="4" selection-start-line="3515" selection-start-column="4" selection-end-line="3515" selection-end-column="4" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="text.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/engine/text.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="210">
+              <caret line="14" column="0" selection-start-line="14" selection-start-column="0" selection-end-line="14" selection-end-column="0" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="player.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/player.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="7575">
+              <caret line="1469" column="17" selection-start-line="1469" selection-start-column="8" selection-end-line="1469" selection-end-column="17" />
               <folding>
-                <element signature="n#!!doc" expanded="true" />
+                <element signature="e#2456#7373#0" expanded="false" />
+                <element signature="e#7441#8055#0" expanded="false" />
+                <element signature="e#8123#8677#0" expanded="false" />
+                <element signature="e#8747#9348#0" expanded="false" />
+                <element signature="e#9490#10150#0" expanded="false" />
+                <element signature="e#10196#10691#0" expanded="false" />
+                <element signature="e#10755#11335#0" expanded="false" />
+                <element signature="e#11405#11782#0" expanded="false" />
+                <element signature="e#11845#12472#0" expanded="false" />
+                <element signature="e#12515#13045#0" expanded="false" />
+                <element signature="e#13090#13599#0" expanded="false" />
+                <element signature="e#13663#14362#0" expanded="false" />
+                <element signature="e#14426#15092#0" expanded="false" />
+                <element signature="e#15162#15661#0" expanded="false" />
+                <element signature="e#15705#16102#0" expanded="false" />
+                <element signature="e#16170#16665#0" expanded="false" />
+                <element signature="e#16737#18894#0" expanded="false" />
+                <element signature="e#18964#19984#0" expanded="false" />
+                <element signature="e#20042#20622#0" expanded="false" />
+                <element signature="e#20674#21034#0" expanded="false" />
+                <element signature="e#21088#21410#0" expanded="false" />
+                <element signature="e#21466#22192#0" expanded="false" />
+                <element signature="e#22248#22762#0" expanded="false" />
+                <element signature="e#22818#23249#0" expanded="false" />
+                <element signature="e#23305#23712#0" expanded="false" />
+                <element signature="e#23782#24860#0" expanded="false" />
+                <element signature="e#24915#25343#0" expanded="false" />
+                <element signature="e#25384#25780#0" expanded="false" />
+                <element signature="e#25823#26354#0" expanded="false" />
+                <element signature="e#26397#26897#0" expanded="false" />
+                <element signature="e#26942#27559#0" expanded="false" />
+                <element signature="e#27601#28224#0" expanded="false" />
+                <element signature="e#28281#28877#0" expanded="false" />
+                <element signature="e#28936#29809#0" expanded="false" />
+                <element signature="e#43620#44374#0" expanded="false" />
+                <element signature="e#44443#44568#0" expanded="false" />
+                <element signature="e#44642#44819#0" expanded="false" />
+                <element signature="e#44893#45139#0" expanded="false" />
+                <element signature="e#45202#53510#0" expanded="false" />
+                <element signature="e#53564#53676#0" expanded="false" />
+                <element signature="e#53735#53756#0" expanded="false" />
+                <element signature="e#53799#53820#0" expanded="false" />
+                <element signature="e#53880#53884#0" expanded="false" />
+                <element signature="e#53935#54011#0" expanded="false" />
+                <element signature="e#54062#54228#0" expanded="false" />
+                <element signature="e#54280#54439#0" expanded="false" />
+                <element signature="e#54497#54594#0" expanded="false" />
+                <element signature="e#54641#54806#0" expanded="false" />
+                <element signature="e#54863#55054#0" expanded="false" />
+                <element signature="e#55096#55291#0" expanded="false" />
+                <element signature="e#55733#55773#0" expanded="false" />
+                <element signature="e#55826#55866#0" expanded="false" />
+                <element signature="e#55913#56076#0" expanded="false" />
+                <element signature="e#56125#56322#0" expanded="false" />
               </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="time.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/engine/time.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="83">
+              <caret line="29" column="4" selection-start-line="29" selection-start-column="4" selection-end-line="29" selection-end-column="4" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="saves.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/engine/saves.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="199">
+              <caret line="220" column="8" selection-start-line="220" selection-start-column="8" selection-end-line="220" selection-end-column="8" />
+              <folding>
+                <element signature="e#2171#2385#0" expanded="false" />
+                <element signature="e#2476#2621#0" expanded="false" />
+                <element signature="e#2717#2864#0" expanded="false" />
+                <element signature="e#3035#3834#0" expanded="false" />
+                <element signature="e#4083#4450#0" expanded="false" />
+                <element signature="e#4541#5046#0" expanded="false" />
+                <element signature="e#5872#6413#0" expanded="false" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="pregnancy.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/pregnancy.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="3090">
+              <caret line="202" column="0" selection-start-line="202" selection-start-column="0" selection-end-line="202" selection-end-column="0" />
+              <folding />
             </state>
           </provider>
         </entry>
@@ -142,7 +221,6 @@
   <component name="IdeDocumentHistory">
     <option name="CHANGED_PATHS">
       <list>
-        <option value="$PROJECT_DIR$/js/scenes/areas/lake/callu.js" />
         <option value="$PROJECT_DIR$/js/scenes/areas/forest/tentacleBeast.js" />
         <option value="$PROJECT_DIR$/js/scenes/intro.js" />
         <option value="$PROJECT_DIR$/js/flags/legacyFlags.js" />
@@ -177,22 +255,23 @@
         <option value="$PROJECT_DIR$/js/keyItemClass.js" />
         <option value="$PROJECT_DIR$/js/scenes/places/townruins.js" />
         <option value="$PROJECT_DIR$/js/engine/utils.js" />
-        <option value="$PROJECT_DIR$/js/engine/saves.js" />
         <option value="$PROJECT_DIR$/js/scenes/inventory.js" />
         <option value="$PROJECT_DIR$/js/keyItemLib.js" />
-        <option value="$PROJECT_DIR$/js/player.js" />
         <option value="$PROJECT_DIR$/js/scenes/combatTeases.js" />
         <option value="$PROJECT_DIR$/js/scenes/combat.js" />
         <option value="$PROJECT_DIR$/js/appearance.js" />
         <option value="$PROJECT_DIR$/coc.html" />
         <option value="$PROJECT_DIR$/js/pp.js" />
-        <option value="$PROJECT_DIR$/js/engine/time.js" />
-        <option value="$PROJECT_DIR$/js/creature.js" />
-        <option value="$PROJECT_DIR$/js/pregnancy.js" />
-        <option value="$PROJECT_DIR$/js/scenes/camp.js" />
         <option value="$PROJECT_DIR$/js/flags/dataFlags.js" />
-        <option value="$PROJECT_DIR$/js/pregnancyProgression.js" />
+        <option value="$PROJECT_DIR$/js/statusEffectClass.js" />
+        <option value="$PROJECT_DIR$/js/pregnancy.js" />
+        <option value="$PROJECT_DIR$/js/engine/time.js" />
+        <option value="$PROJECT_DIR$/js/player.js" />
         <option value="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
+        <option value="$PROJECT_DIR$/js/engine/saves.js" />
+        <option value="$PROJECT_DIR$/js/scenes/camp.js" />
+        <option value="$PROJECT_DIR$/js/pregnancyProgression.js" />
+        <option value="$PROJECT_DIR$/js/creature.js" />
       </list>
     </option>
   </component>
@@ -260,166 +339,15 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="ProjectPane">
-        <subPane>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="js" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="js" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="scenes" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="js" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="scenes" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="npcs" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="js" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="scenes" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="monsters" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="js" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="scenes" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="areas" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="js" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="flags" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-          <PATH>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="Corruption-of-Champions-HTML" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="js" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-            <PATH_ELEMENT>
-              <option name="myItemId" value="engine" />
-              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
-            </PATH_ELEMENT>
-          </PATH>
-        </subPane>
-      </pane>
       <pane id="Scope" />
       <pane id="Scratches" />
+      <pane id="ProjectPane">
+        <subPane />
+      </pane>
     </panes>
   </component>
   <component name="PropertiesComponent">
-    <property name="last_opened_file_path" value="$USER_HOME$/Downloads/Corruption-of-Champions-Mod-master/classes/classes/Monster.as" />
+    <property name="last_opened_file_path" value="$USER_HOME$/Downloads/Corruption-of-Champions-Mod-master/classes/classes/Saves.as" />
     <property name="WebServerToolWindowFactoryState" value="false" />
     <property name="HbShouldOpenHtmlAsHb" value="" />
     <property name="settings.editor.selected.configurable" value="preferences.fileTypes" />
@@ -429,15 +357,15 @@
     <property name="SearchEverywhereHistoryKey" value="&#9;FILE&#9;file:///home/sudhamma/Projects/Corruption-of-Champions-HTML/js/scenes/npcs/amily.js" />
   </component>
   <component name="RecentsManager">
-    <key name="MoveFile.RECENT_KEYS">
-      <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\sprites" />
-      <recent name="G:\Sylvain\Data Files\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\js\scenes" />
-      <recent name="G:\Sylvain\Data Files\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\js" />
-    </key>
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/js" />
       <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\sprites" />
       <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\interface" />
+    </key>
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\sprites" />
+      <recent name="G:\Sylvain\Data Files\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\js\scenes" />
+      <recent name="G:\Sylvain\Data Files\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\js" />
     </key>
   </component>
   <component name="RunManager" selected="JavaScript Debug.coc.html">
@@ -536,6 +464,7 @@
       <workItem from="1467063180164" duration="8158000" />
       <workItem from="1467285999679" duration="3444000" />
       <workItem from="1467421291015" duration="24611000" />
+      <workItem from="1467564889905" duration="23680000" />
     </task>
     <task id="LOCAL-00001" summary="Release of 0.1 alpha with many more core content!&#10;&#10;Now with explorable zones, followers, etc!">
       <created>1455694082885</created>
@@ -562,7 +491,7 @@
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="125775000" />
+    <option name="totallyTimeSpent" value="149455000" />
   </component>
   <component name="TodoView" selected-index="4">
     <todo-panel id="selected-file">
@@ -577,16 +506,16 @@
     <frame x="0" y="27" width="1366" height="741" extended-state="6" />
     <editor active="true" />
     <layout>
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.24158126" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.24158126" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
       <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32854864" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
-      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32854864" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="9" side_tool="false" content_ui="tabs" />
       <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="8" side_tool="false" content_ui="tabs" />
       <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="true" content_ui="tabs" />
-      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.36204147" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.49920255" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="Cvs" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
       <window_info id="Messages" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
@@ -642,39 +571,11 @@
           <properties />
         </breakpoint>
       </default-breakpoints>
-      <option name="time" value="57" />
+      <option name="time" value="81" />
     </breakpoint-manager>
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/js/scenes/places/farm/whitney.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="38" column="5" selection-start-line="38" selection-start-column="5" selection-end-line="38" selection-end-column="5" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/npcs/marble.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="107" column="3" selection-start-line="107" selection-start-column="3" selection-end-line="107" selection-end-column="3" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/items/transformationEffects.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="23" column="6" selection-start-line="23" selection-start-column="6" selection-end-line="23" selection-end-column="6" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/globalVariables.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="24" column="29" selection-start-line="24" selection-start-column="29" selection-end-line="24" selection-end-column="29" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/js/scenes/areas/desert/marcusLucia.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="1395">
@@ -757,16 +658,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/npcs/giacomo.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="111">
-          <caret line="235" column="21" selection-start-line="235" selection-start-column="18" selection-end-line="235" selection-end-column="21" />
-          <folding>
-            <element signature="n#!!doc" expanded="false" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/js/keyItemLib.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="520">
@@ -829,7 +720,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="345">
           <caret line="18" column="64" selection-start-line="18" selection-start-column="64" selection-end-line="18" selection-end-column="64" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -882,15 +772,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="150">
           <caret line="10" column="24" selection-start-line="7" selection-start-column="4" selection-end-line="10" selection-end-column="24" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/combat.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="66">
-          <caret line="39" column="12" selection-start-line="39" selection-start-column="11" selection-end-line="39" selection-end-column="12" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -898,7 +779,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="555">
           <caret line="37" column="18" selection-start-line="37" selection-start-column="18" selection-end-line="37" selection-end-column="18" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -910,22 +790,7 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/pp.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/saves.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="122">
-          <caret line="10" column="6" selection-start-line="10" selection-start-column="6" selection-end-line="10" selection-end-column="6" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
+    <entry file="file://$PROJECT_DIR$/js/pp.js" />
     <entry file="file://$PROJECT_DIR$/js/appearance.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="3141">
@@ -934,10 +799,74 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/input.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="144">
+          <caret line="98" column="10" selection-start-line="98" selection-start-column="8" selection-end-line="98" selection-end-column="10" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/Downloads/Corruption-of-Champions-Mod-master/classes/classes/Saves.as">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/statusEffectClass.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="30">
+          <caret line="2" column="4" selection-start-line="2" selection-start-column="4" selection-end-line="2" selection-end-column="4" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/utils.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1635">
+          <caret line="108" column="8" selection-start-line="108" selection-start-column="8" selection-end-line="108" selection-end-column="8" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/combat.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="152">
+          <caret line="628" column="26" selection-start-line="628" selection-start-column="26" selection-end-line="628" selection-end-column="26" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/npcs/marble.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/npcs/giacomo.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-2205">
+          <caret line="235" column="21" selection-start-line="235" selection-start-column="18" selection-end-line="235" selection-end-column="21" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/gui.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="94">
+          <caret line="9" column="25" selection-start-line="9" selection-start-column="25" selection-end-line="9" selection-end-column="25" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/js/player.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-2905">
-          <caret line="1111" column="32" selection-start-line="1111" selection-start-column="30" selection-end-line="1111" selection-end-column="32" />
+        <state relative-caret-position="7575">
+          <caret line="1469" column="17" selection-start-line="1469" selection-start-column="8" selection-end-line="1469" selection-end-column="17" />
           <folding>
             <element signature="e#2456#7373#0" expanded="false" />
             <element signature="e#7441#8055#0" expanded="false" />
@@ -997,132 +926,83 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/utils.js">
+    <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="111">
-          <caret line="54" column="7" selection-start-line="54" selection-start-column="5" selection-end-line="54" selection-end-column="7" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/input.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="144">
-          <caret line="98" column="10" selection-start-line="98" selection-start-column="8" selection-end-line="98" selection-end-column="10" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/gui.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="144">
-          <caret line="156" column="15" selection-start-line="156" selection-start-column="15" selection-end-line="156" selection-end-column="15" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/time.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="263">
-          <caret line="42" column="4" selection-start-line="42" selection-start-column="4" selection-end-line="42" selection-end-column="4" />
-          <folding>
-            <element signature="n#!!doc" expanded="false" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/creature.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="52">
-          <caret line="266" column="27" selection-start-line="266" selection-start-column="19" selection-end-line="266" selection-end-column="27" />
+        <state relative-caret-position="56">
+          <caret line="120" column="0" selection-start-line="120" selection-start-column="0" selection-end-line="120" selection-end-column="0" />
           <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/js/pregnancy.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="135">
-          <caret line="129" column="39" selection-start-line="129" selection-start-column="39" selection-end-line="129" selection-end-column="39" />
+        <state relative-caret-position="3090">
+          <caret line="202" column="0" selection-start-line="202" selection-start-column="0" selection-end-line="202" selection-end-column="0" />
           <folding />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
+    <entry file="file://$PROJECT_DIR$/js/engine/text.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="240">
-          <caret line="67" column="6" selection-start-line="67" selection-start-column="6" selection-end-line="67" selection-end-column="6" />
+        <state relative-caret-position="210">
+          <caret line="14" column="0" selection-start-line="14" selection-start-column="0" selection-end-line="14" selection-end-column="0" />
           <folding />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
+    <entry file="file://$PROJECT_DIR$/js/engine/saves.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="281">
-          <caret line="121" column="0" selection-start-line="121" selection-start-column="0" selection-end-line="121" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="120">
-          <caret line="7" column="0" selection-start-line="7" selection-start-column="0" selection-end-line="7" selection-end-column="0" />
+        <state relative-caret-position="199">
+          <caret line="220" column="8" selection-start-line="220" selection-start-column="8" selection-end-line="220" selection-end-column="8" />
           <folding>
-            <element signature="n#!!doc" expanded="true" />
+            <element signature="e#2171#2385#0" expanded="false" />
+            <element signature="e#2476#2621#0" expanded="false" />
+            <element signature="e#2717#2864#0" expanded="false" />
+            <element signature="e#3035#3834#0" expanded="false" />
+            <element signature="e#4083#4450#0" expanded="false" />
+            <element signature="e#4541#5046#0" expanded="false" />
+            <element signature="e#5872#6413#0" expanded="false" />
           </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="165">
-          <caret line="32" column="0" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
-          <folding>
-            <element signature="n#!!block;n#Amily#0" expanded="false" />
-            <element signature="e#5241#5455#0" expanded="false" />
-            <element signature="e#5561#5656#0" expanded="false" />
-            <element signature="e#11015#11357#0" expanded="false" />
-            <element signature="e#11415#22544#0" expanded="false" />
-            <element signature="e#43510#51214#0" expanded="false" />
-            <element signature="e#51328#52182#0" expanded="false" />
-            <element signature="e#52340#53102#0" expanded="false" />
-            <element signature="e#53228#53520#0" expanded="false" />
-            <element signature="e#53679#54123#0" expanded="false" />
-            <element signature="e#54228#54734#0" expanded="false" />
-            <element signature="e#55050#55947#0" expanded="false" />
-            <element signature="e#56169#57611#0" expanded="false" />
-            <element signature="e#57728#59553#0" expanded="false" />
-            <element signature="e#59652#61263#0" expanded="false" />
-            <element signature="e#61375#63817#0" expanded="false" />
-            <element signature="e#63953#64534#0" expanded="false" />
-            <element signature="e#64669#66498#0" expanded="false" />
-            <element signature="e#66610#67786#0" expanded="false" />
-            <element signature="e#67896#69305#0" expanded="false" />
-            <element signature="e#69406#70078#0" expanded="false" />
-            <element signature="e#70296#71442#0" expanded="false" />
-            <element signature="e#74519#77538#0" expanded="false" />
-            <element signature="e#77628#79092#0" expanded="false" />
-            <element signature="e#79180#79799#0" expanded="false" />
-            <element signature="e#79885#80612#0" expanded="false" />
-            <element signature="e#80779#100820#0" expanded="false" />
-            <element signature="e#100965#103813#0" expanded="false" />
-            <element signature="e#103913#152802#0" expanded="false" />
-            <element signature="e#152887#159450#0" expanded="false" />
-            <element signature="e#159547#159625#0" expanded="false" />
-            <element signature="e#159797#163535#0" expanded="false" />
-            <element signature="e#163680#166772#0" expanded="false" />
-            <element signature="e#163682#163748#0" expanded="false" />
-            <element signature="e#164068#164522#0" expanded="false" />
-            <element signature="e#164648#166581#0" expanded="false" />
-            <element signature="e#166661#166769#0" expanded="false" />
-            <element signature="e#166886#173321#0" expanded="false" />
-            <element signature="e#238411#239255#0" expanded="false" />
-            <element signature="e#239319#240347#0" expanded="false" />
-            <element signature="e#240411#241076#0" expanded="false" />
-            <element signature="e#241140#243583#0" expanded="false" />
-            <element signature="e#243646#248112#0" expanded="false" />
-            <element signature="e#337569#340622#0" expanded="false" />
-          </folding>
+        <state relative-caret-position="204">
+          <caret line="112" column="4" selection-start-line="112" selection-start-column="4" selection-end-line="112" selection-end-column="4" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="229">
+          <caret line="121" column="49" selection-start-line="121" selection-start-column="49" selection-end-line="121" selection-end-column="49" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="120">
+          <caret line="67" column="6" selection-start-line="67" selection-start-column="6" selection-end-line="67" selection-end-column="6" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/time.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="83">
+          <caret line="29" column="4" selection-start-line="29" selection-start-column="4" selection-end-line="29" selection-end-column="4" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/creature.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="94">
+          <caret line="3515" column="4" selection-start-line="3515" selection-start-column="4" selection-end-line="3515" selection-end-column="4" />
+          <folding />
         </state>
       </provider>
     </entry>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,7 +7,12 @@
   <component name="ChangeListManager">
     <list default="true" id="8a292ce1-df00-4848-8a40-d7241dab169d" name="Default" comment="">
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/engine/time.js" afterPath="$PROJECT_DIR$/js/engine/time.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/flags/dataFlags.js" afterPath="$PROJECT_DIR$/js/flags/dataFlags.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/pregnancy.js" afterPath="$PROJECT_DIR$/js/pregnancy.js" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/pregnancyProgression.js" afterPath="$PROJECT_DIR$/js/pregnancyProgression.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/camp.js" afterPath="$PROJECT_DIR$/js/scenes/camp.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/npcs/amily.js" afterPath="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
     </list>
     <ignored path="Corruption-of-Champions-HTML.iws" />
     <ignored path=".idea/workspace.xml" />
@@ -28,166 +33,66 @@
   </component>
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-      <file leaf-file-name="amily.js" pinned="false" current-in-tab="false">
+      <file leaf-file-name="amily.js" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-1147">
+            <state relative-caret-position="165">
               <caret line="32" column="0" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
               <folding>
                 <element signature="n#!!block;n#Amily#0" expanded="false" />
-                <element signature="e#5184#5398#0" expanded="false" />
-                <element signature="e#5504#5599#0" expanded="false" />
-                <element signature="e#10958#11300#0" expanded="false" />
-                <element signature="e#11358#22487#0" expanded="false" />
-                <element signature="e#43453#51157#0" expanded="false" />
-                <element signature="e#51271#52125#0" expanded="false" />
-                <element signature="e#52283#53045#0" expanded="false" />
-                <element signature="e#53171#53463#0" expanded="false" />
-                <element signature="e#53622#54066#0" expanded="false" />
-                <element signature="e#54171#54677#0" expanded="false" />
-                <element signature="e#54993#55890#0" expanded="false" />
-                <element signature="e#56112#57554#0" expanded="false" />
-                <element signature="e#57671#59496#0" expanded="false" />
-                <element signature="e#59595#61206#0" expanded="false" />
-                <element signature="e#61318#63760#0" expanded="false" />
-                <element signature="e#63896#64477#0" expanded="false" />
-                <element signature="e#64612#66441#0" expanded="false" />
-                <element signature="e#66553#67729#0" expanded="false" />
-                <element signature="e#67839#69248#0" expanded="false" />
-                <element signature="e#69349#70021#0" expanded="false" />
-                <element signature="e#70239#71385#0" expanded="false" />
-                <element signature="e#74462#77481#0" expanded="false" />
-                <element signature="e#77571#79035#0" expanded="false" />
-                <element signature="e#79123#79742#0" expanded="false" />
-                <element signature="e#79828#80555#0" expanded="false" />
-                <element signature="e#80722#100763#0" expanded="false" />
-                <element signature="e#100908#103756#0" expanded="false" />
-                <element signature="e#103856#152745#0" expanded="false" />
-                <element signature="e#152830#159393#0" expanded="false" />
-                <element signature="e#159490#159568#0" expanded="false" />
-                <element signature="e#159740#163478#0" expanded="false" />
-                <element signature="e#163623#166715#0" expanded="false" />
-                <element signature="e#163625#163691#0" expanded="false" />
-                <element signature="e#164011#164465#0" expanded="false" />
-                <element signature="e#164591#166524#0" expanded="false" />
-                <element signature="e#166604#166712#0" expanded="false" />
-                <element signature="e#166829#173264#0" expanded="false" />
-                <element signature="e#326683#329735#0" expanded="false" />
+                <element signature="e#5241#5455#0" expanded="false" />
+                <element signature="e#5561#5656#0" expanded="false" />
+                <element signature="e#11015#11357#0" expanded="false" />
+                <element signature="e#11415#22544#0" expanded="false" />
+                <element signature="e#43510#51214#0" expanded="false" />
+                <element signature="e#51328#52182#0" expanded="false" />
+                <element signature="e#52340#53102#0" expanded="false" />
+                <element signature="e#53228#53520#0" expanded="false" />
+                <element signature="e#53679#54123#0" expanded="false" />
+                <element signature="e#54228#54734#0" expanded="false" />
+                <element signature="e#55050#55947#0" expanded="false" />
+                <element signature="e#56169#57611#0" expanded="false" />
+                <element signature="e#57728#59553#0" expanded="false" />
+                <element signature="e#59652#61263#0" expanded="false" />
+                <element signature="e#61375#63817#0" expanded="false" />
+                <element signature="e#63953#64534#0" expanded="false" />
+                <element signature="e#64669#66498#0" expanded="false" />
+                <element signature="e#66610#67786#0" expanded="false" />
+                <element signature="e#67896#69305#0" expanded="false" />
+                <element signature="e#69406#70078#0" expanded="false" />
+                <element signature="e#70296#71442#0" expanded="false" />
+                <element signature="e#74519#77538#0" expanded="false" />
+                <element signature="e#77628#79092#0" expanded="false" />
+                <element signature="e#79180#79799#0" expanded="false" />
+                <element signature="e#79885#80612#0" expanded="false" />
+                <element signature="e#80779#100820#0" expanded="false" />
+                <element signature="e#100965#103813#0" expanded="false" />
+                <element signature="e#103913#152802#0" expanded="false" />
+                <element signature="e#152887#159450#0" expanded="false" />
+                <element signature="e#159547#159625#0" expanded="false" />
+                <element signature="e#159797#163535#0" expanded="false" />
+                <element signature="e#163680#166772#0" expanded="false" />
+                <element signature="e#163682#163748#0" expanded="false" />
+                <element signature="e#164068#164522#0" expanded="false" />
+                <element signature="e#164648#166581#0" expanded="false" />
+                <element signature="e#166661#166769#0" expanded="false" />
+                <element signature="e#166886#173321#0" expanded="false" />
+                <element signature="e#238411#239255#0" expanded="false" />
+                <element signature="e#239319#240347#0" expanded="false" />
+                <element signature="e#240411#241076#0" expanded="false" />
+                <element signature="e#241140#243583#0" expanded="false" />
+                <element signature="e#243646#248112#0" expanded="false" />
+                <element signature="e#337569#340622#0" expanded="false" />
               </folding>
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="appearance.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/js/appearance.js">
+      <file leaf-file-name="dataFlags.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="3141">
-              <caret line="2364" column="12" selection-start-line="2364" selection-start-column="12" selection-end-line="2364" selection-end-column="12" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="creature.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/js/creature.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-84">
-              <caret line="1318" column="47" selection-start-line="1318" selection-start-column="35" selection-end-line="1318" selection-end-column="47" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="player.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/js/player.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="111">
-              <caret line="1111" column="32" selection-start-line="1111" selection-start-column="30" selection-end-line="1111" selection-end-column="32" />
-              <folding>
-                <element signature="e#2456#7373#0" expanded="false" />
-                <element signature="e#7441#8055#0" expanded="false" />
-                <element signature="e#8123#8677#0" expanded="false" />
-                <element signature="e#8747#9348#0" expanded="false" />
-                <element signature="e#9490#10150#0" expanded="false" />
-                <element signature="e#10196#10691#0" expanded="false" />
-                <element signature="e#10755#11335#0" expanded="false" />
-                <element signature="e#11405#11782#0" expanded="false" />
-                <element signature="e#11845#12472#0" expanded="false" />
-                <element signature="e#12515#13045#0" expanded="false" />
-                <element signature="e#13090#13599#0" expanded="false" />
-                <element signature="e#13663#14362#0" expanded="false" />
-                <element signature="e#14426#15092#0" expanded="false" />
-                <element signature="e#15162#15661#0" expanded="false" />
-                <element signature="e#15705#16102#0" expanded="false" />
-                <element signature="e#16170#16665#0" expanded="false" />
-                <element signature="e#16737#18894#0" expanded="false" />
-                <element signature="e#18964#19984#0" expanded="false" />
-                <element signature="e#20042#20622#0" expanded="false" />
-                <element signature="e#20674#21034#0" expanded="false" />
-                <element signature="e#21088#21410#0" expanded="false" />
-                <element signature="e#21466#22192#0" expanded="false" />
-                <element signature="e#22248#22762#0" expanded="false" />
-                <element signature="e#22818#23249#0" expanded="false" />
-                <element signature="e#23305#23712#0" expanded="false" />
-                <element signature="e#23782#24860#0" expanded="false" />
-                <element signature="e#24915#25343#0" expanded="false" />
-                <element signature="e#25384#25780#0" expanded="false" />
-                <element signature="e#25823#26354#0" expanded="false" />
-                <element signature="e#26397#26897#0" expanded="false" />
-                <element signature="e#26942#27559#0" expanded="false" />
-                <element signature="e#27601#28224#0" expanded="false" />
-                <element signature="e#28281#28877#0" expanded="false" />
-                <element signature="e#28936#29809#0" expanded="false" />
-                <element signature="e#43620#44374#0" expanded="false" />
-                <element signature="e#44443#44568#0" expanded="false" />
-                <element signature="e#44642#44819#0" expanded="false" />
-                <element signature="e#44893#45139#0" expanded="false" />
-                <element signature="e#45202#53510#0" expanded="false" />
-                <element signature="e#53564#53676#0" expanded="false" />
-                <element signature="e#53735#53756#0" expanded="false" />
-                <element signature="e#53799#53820#0" expanded="false" />
-                <element signature="e#53880#53884#0" expanded="false" />
-                <element signature="e#53935#54011#0" expanded="false" />
-                <element signature="e#54062#54228#0" expanded="false" />
-                <element signature="e#54280#54439#0" expanded="false" />
-                <element signature="e#54497#54594#0" expanded="false" />
-                <element signature="e#54641#54806#0" expanded="false" />
-                <element signature="e#54863#55054#0" expanded="false" />
-                <element signature="e#55096#55291#0" expanded="false" />
-                <element signature="e#55733#55773#0" expanded="false" />
-                <element signature="e#55826#55866#0" expanded="false" />
-                <element signature="e#55913#56076#0" expanded="false" />
-                <element signature="e#56125#56322#0" expanded="false" />
-              </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="time.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/js/engine/time.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="173">
-              <caret line="36" column="22" selection-start-line="36" selection-start-column="22" selection-end-line="36" selection-end-column="22" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="pregnancyProgression.js" pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="195">
-              <caret line="12" column="2" selection-start-line="12" selection-start-column="2" selection-end-line="12" selection-end-column="2" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="pregnancy.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/js/pregnancy.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-195">
-              <caret line="131" column="53" selection-start-line="131" selection-start-column="53" selection-end-line="131" selection-end-column="53" />
+            <state relative-caret-position="281">
+              <caret line="121" column="0" selection-start-line="121" selection-start-column="0" selection-end-line="121" selection-end-column="0" />
               <folding />
             </state>
           </provider>
@@ -196,19 +101,21 @@
       <file leaf-file-name="camp.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="525">
-              <caret line="62" column="75" selection-start-line="62" selection-start-column="75" selection-end-line="62" selection-end-column="75" />
+            <state relative-caret-position="240">
+              <caret line="67" column="6" selection-start-line="67" selection-start-column="6" selection-end-line="67" selection-end-column="6" />
               <folding />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="dataFlags.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
+      <file leaf-file-name="pregnancyProgression.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="150">
-              <caret line="10" column="98" selection-start-line="10" selection-start-column="98" selection-end-line="10" selection-end-column="98" />
-              <folding />
+            <state relative-caret-position="120">
+              <caret line="7" column="0" selection-start-line="7" selection-start-column="0" selection-end-line="7" selection-end-column="0" />
+              <folding>
+                <element signature="n#!!doc" expanded="true" />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -265,7 +172,6 @@
         <option value="$PROJECT_DIR$/js/scenes/areas/desert/sandWitch.js" />
         <option value="$PROJECT_DIR$/js/globalVariables.js" />
         <option value="$PROJECT_DIR$/js/scenes/npcs/rathazul.js" />
-        <option value="$PROJECT_DIR$/js/engine/time.js" />
         <option value="$PROJECT_DIR$/js/items/consumables.js" />
         <option value="$PROJECT_DIR$/js/items/keyItems.js" />
         <option value="$PROJECT_DIR$/js/keyItemClass.js" />
@@ -274,18 +180,19 @@
         <option value="$PROJECT_DIR$/js/engine/saves.js" />
         <option value="$PROJECT_DIR$/js/scenes/inventory.js" />
         <option value="$PROJECT_DIR$/js/keyItemLib.js" />
-        <option value="$PROJECT_DIR$/js/pregnancy.js" />
         <option value="$PROJECT_DIR$/js/player.js" />
         <option value="$PROJECT_DIR$/js/scenes/combatTeases.js" />
-        <option value="$PROJECT_DIR$/js/flags/dataFlags.js" />
         <option value="$PROJECT_DIR$/js/scenes/combat.js" />
-        <option value="$PROJECT_DIR$/js/creature.js" />
-        <option value="$PROJECT_DIR$/js/scenes/camp.js" />
         <option value="$PROJECT_DIR$/js/appearance.js" />
-        <option value="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
         <option value="$PROJECT_DIR$/coc.html" />
         <option value="$PROJECT_DIR$/js/pp.js" />
+        <option value="$PROJECT_DIR$/js/engine/time.js" />
+        <option value="$PROJECT_DIR$/js/creature.js" />
+        <option value="$PROJECT_DIR$/js/pregnancy.js" />
+        <option value="$PROJECT_DIR$/js/scenes/camp.js" />
+        <option value="$PROJECT_DIR$/js/flags/dataFlags.js" />
         <option value="$PROJECT_DIR$/js/pregnancyProgression.js" />
+        <option value="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
       </list>
     </option>
   </component>
@@ -515,7 +422,7 @@
     <property name="last_opened_file_path" value="$USER_HOME$/Downloads/Corruption-of-Champions-Mod-master/classes/classes/Monster.as" />
     <property name="WebServerToolWindowFactoryState" value="false" />
     <property name="HbShouldOpenHtmlAsHb" value="" />
-    <property name="settings.editor.selected.configurable" value="preferences.editor" />
+    <property name="settings.editor.selected.configurable" value="preferences.fileTypes" />
     <property name="settings.editor.splitter.proportion" value="0.2" />
     <property name="jsx.switch.disabled" value="true" />
     <property name="DefaultHtmlFileTemplate" value="HTML File" />
@@ -628,7 +535,7 @@
       <workItem from="1466946857377" duration="28680000" />
       <workItem from="1467063180164" duration="8158000" />
       <workItem from="1467285999679" duration="3444000" />
-      <workItem from="1467421291015" duration="11309000" />
+      <workItem from="1467421291015" duration="24611000" />
     </task>
     <task id="LOCAL-00001" summary="Release of 0.1 alpha with many more core content!&#10;&#10;Now with explorable zones, followers, etc!">
       <created>1455694082885</created>
@@ -655,7 +562,7 @@
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="112473000" />
+    <option name="totallyTimeSpent" value="125775000" />
   </component>
   <component name="TodoView" selected-index="4">
     <todo-panel id="selected-file">
@@ -695,7 +602,7 @@
       <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
       <window_info id="Commander" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
       <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32854864" sideWeight="0.5" order="8" side_tool="true" content_ui="tabs" />
-      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.3891547" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.3891547" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="10" side_tool="false" content_ui="tabs" />
       <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="9" side_tool="false" content_ui="tabs" />
@@ -735,7 +642,7 @@
           <properties />
         </breakpoint>
       </default-breakpoints>
-      <option name="time" value="47" />
+      <option name="time" value="57" />
     </breakpoint-manager>
     <watches-manager />
   </component>
@@ -814,24 +721,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/gui.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="730">
-          <caret line="103" column="0" selection-start-line="103" selection-start-column="0" selection-end-line="103" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/js/scenes/npcs/jojo.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="165">
           <caret line="11" column="24" selection-start-line="11" selection-start-column="24" selection-end-line="11" selection-end-column="24" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/input.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="93">
-          <caret line="94" column="50" selection-start-line="94" selection-start-column="50" selection-end-line="94" selection-end-column="50" />
         </state>
       </provider>
     </entry>
@@ -871,20 +764,6 @@
           <folding>
             <element signature="n#!!doc" expanded="false" />
           </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/saves.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-1540">
-          <caret line="158" column="73" selection-start-line="158" selection-start-column="73" selection-end-line="158" selection-end-column="73" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/utils.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="188">
-          <caret line="77" column="21" selection-start-line="77" selection-start-column="11" selection-end-line="77" selection-end-column="21" />
         </state>
       </provider>
     </entry>
@@ -1023,26 +902,26 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
+    <entry file="file://$PROJECT_DIR$/coc.html">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="150">
-          <caret line="10" column="98" selection-start-line="10" selection-start-column="98" selection-end-line="10" selection-end-column="98" />
+        <state relative-caret-position="118">
+          <caret line="98" column="72" selection-start-line="98" selection-start-column="72" selection-end-line="98" selection-end-column="72" />
           <folding />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
+    <entry file="file://$PROJECT_DIR$/js/pp.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="525">
-          <caret line="62" column="75" selection-start-line="62" selection-start-column="75" selection-end-line="62" selection-end-column="75" />
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/creature.js">
+    <entry file="file://$PROJECT_DIR$/js/engine/saves.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-84">
-          <caret line="1318" column="47" selection-start-line="1318" selection-start-column="35" selection-end-line="1318" selection-end-column="47" />
+        <state relative-caret-position="122">
+          <caret line="10" column="6" selection-start-line="10" selection-start-column="6" selection-end-line="10" selection-end-column="6" />
           <folding />
         </state>
       </provider>
@@ -1055,81 +934,9 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-1147">
-          <caret line="32" column="0" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
-          <folding>
-            <element signature="n#!!block;n#Amily#0" expanded="false" />
-            <element signature="e#5184#5398#0" expanded="false" />
-            <element signature="e#5504#5599#0" expanded="false" />
-            <element signature="e#10958#11300#0" expanded="false" />
-            <element signature="e#11358#22487#0" expanded="false" />
-            <element signature="e#43453#51157#0" expanded="false" />
-            <element signature="e#51271#52125#0" expanded="false" />
-            <element signature="e#52283#53045#0" expanded="false" />
-            <element signature="e#53171#53463#0" expanded="false" />
-            <element signature="e#53622#54066#0" expanded="false" />
-            <element signature="e#54171#54677#0" expanded="false" />
-            <element signature="e#54993#55890#0" expanded="false" />
-            <element signature="e#56112#57554#0" expanded="false" />
-            <element signature="e#57671#59496#0" expanded="false" />
-            <element signature="e#59595#61206#0" expanded="false" />
-            <element signature="e#61318#63760#0" expanded="false" />
-            <element signature="e#63896#64477#0" expanded="false" />
-            <element signature="e#64612#66441#0" expanded="false" />
-            <element signature="e#66553#67729#0" expanded="false" />
-            <element signature="e#67839#69248#0" expanded="false" />
-            <element signature="e#69349#70021#0" expanded="false" />
-            <element signature="e#70239#71385#0" expanded="false" />
-            <element signature="e#74462#77481#0" expanded="false" />
-            <element signature="e#77571#79035#0" expanded="false" />
-            <element signature="e#79123#79742#0" expanded="false" />
-            <element signature="e#79828#80555#0" expanded="false" />
-            <element signature="e#80722#100763#0" expanded="false" />
-            <element signature="e#100908#103756#0" expanded="false" />
-            <element signature="e#103856#152745#0" expanded="false" />
-            <element signature="e#152830#159393#0" expanded="false" />
-            <element signature="e#159490#159568#0" expanded="false" />
-            <element signature="e#159740#163478#0" expanded="false" />
-            <element signature="e#163623#166715#0" expanded="false" />
-            <element signature="e#163625#163691#0" expanded="false" />
-            <element signature="e#164011#164465#0" expanded="false" />
-            <element signature="e#164591#166524#0" expanded="false" />
-            <element signature="e#166604#166712#0" expanded="false" />
-            <element signature="e#166829#173264#0" expanded="false" />
-            <element signature="e#326683#329735#0" expanded="false" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/coc.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="118">
-          <caret line="98" column="72" selection-start-line="98" selection-start-column="72" selection-end-line="98" selection-end-column="72" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/pregnancy.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-195">
-          <caret line="131" column="53" selection-start-line="131" selection-start-column="53" selection-end-line="131" selection-end-column="53" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/time.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="173">
-          <caret line="36" column="22" selection-start-line="36" selection-start-column="22" selection-end-line="36" selection-end-column="22" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/js/player.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="111">
+        <state relative-caret-position="-2905">
           <caret line="1111" column="32" selection-start-line="1111" selection-start-column="30" selection-end-line="1111" selection-end-column="32" />
           <folding>
             <element signature="e#2456#7373#0" expanded="false" />
@@ -1190,19 +997,132 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/pp.js">
+    <entry file="file://$PROJECT_DIR$/js/engine/utils.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+        <state relative-caret-position="111">
+          <caret line="54" column="7" selection-start-line="54" selection-start-column="5" selection-end-line="54" selection-end-column="7" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/input.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="144">
+          <caret line="98" column="10" selection-start-line="98" selection-start-column="8" selection-end-line="98" selection-end-column="10" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/gui.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="144">
+          <caret line="156" column="15" selection-start-line="156" selection-start-column="15" selection-end-line="156" selection-end-column="15" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/time.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="263">
+          <caret line="42" column="4" selection-start-line="42" selection-start-column="4" selection-end-line="42" selection-end-column="4" />
+          <folding>
+            <element signature="n#!!doc" expanded="false" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/creature.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="52">
+          <caret line="266" column="27" selection-start-line="266" selection-start-column="19" selection-end-line="266" selection-end-column="27" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/pregnancy.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="135">
+          <caret line="129" column="39" selection-start-line="129" selection-start-column="39" selection-end-line="129" selection-end-column="39" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="240">
+          <caret line="67" column="6" selection-start-line="67" selection-start-column="6" selection-end-line="67" selection-end-column="6" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="281">
+          <caret line="121" column="0" selection-start-line="121" selection-start-column="0" selection-end-line="121" selection-end-column="0" />
           <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="195">
-          <caret line="12" column="2" selection-start-line="12" selection-start-column="2" selection-end-line="12" selection-end-column="2" />
-          <folding />
+        <state relative-caret-position="120">
+          <caret line="7" column="0" selection-start-line="7" selection-start-column="0" selection-end-line="7" selection-end-column="0" />
+          <folding>
+            <element signature="n#!!doc" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="165">
+          <caret line="32" column="0" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
+          <folding>
+            <element signature="n#!!block;n#Amily#0" expanded="false" />
+            <element signature="e#5241#5455#0" expanded="false" />
+            <element signature="e#5561#5656#0" expanded="false" />
+            <element signature="e#11015#11357#0" expanded="false" />
+            <element signature="e#11415#22544#0" expanded="false" />
+            <element signature="e#43510#51214#0" expanded="false" />
+            <element signature="e#51328#52182#0" expanded="false" />
+            <element signature="e#52340#53102#0" expanded="false" />
+            <element signature="e#53228#53520#0" expanded="false" />
+            <element signature="e#53679#54123#0" expanded="false" />
+            <element signature="e#54228#54734#0" expanded="false" />
+            <element signature="e#55050#55947#0" expanded="false" />
+            <element signature="e#56169#57611#0" expanded="false" />
+            <element signature="e#57728#59553#0" expanded="false" />
+            <element signature="e#59652#61263#0" expanded="false" />
+            <element signature="e#61375#63817#0" expanded="false" />
+            <element signature="e#63953#64534#0" expanded="false" />
+            <element signature="e#64669#66498#0" expanded="false" />
+            <element signature="e#66610#67786#0" expanded="false" />
+            <element signature="e#67896#69305#0" expanded="false" />
+            <element signature="e#69406#70078#0" expanded="false" />
+            <element signature="e#70296#71442#0" expanded="false" />
+            <element signature="e#74519#77538#0" expanded="false" />
+            <element signature="e#77628#79092#0" expanded="false" />
+            <element signature="e#79180#79799#0" expanded="false" />
+            <element signature="e#79885#80612#0" expanded="false" />
+            <element signature="e#80779#100820#0" expanded="false" />
+            <element signature="e#100965#103813#0" expanded="false" />
+            <element signature="e#103913#152802#0" expanded="false" />
+            <element signature="e#152887#159450#0" expanded="false" />
+            <element signature="e#159547#159625#0" expanded="false" />
+            <element signature="e#159797#163535#0" expanded="false" />
+            <element signature="e#163680#166772#0" expanded="false" />
+            <element signature="e#163682#163748#0" expanded="false" />
+            <element signature="e#164068#164522#0" expanded="false" />
+            <element signature="e#164648#166581#0" expanded="false" />
+            <element signature="e#166661#166769#0" expanded="false" />
+            <element signature="e#166886#173321#0" expanded="false" />
+            <element signature="e#238411#239255#0" expanded="false" />
+            <element signature="e#239319#240347#0" expanded="false" />
+            <element signature="e#240411#241076#0" expanded="false" />
+            <element signature="e#241140#243583#0" expanded="false" />
+            <element signature="e#243646#248112#0" expanded="false" />
+            <element signature="e#337569#340622#0" expanded="false" />
+          </folding>
         </state>
       </provider>
     </entry>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,20 @@
     <option name="SCOPE_TYPE" value="3" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="8a292ce1-df00-4848-8a40-d7241dab169d" name="Default" comment="" />
+    <list default="true" id="8a292ce1-df00-4848-8a40-d7241dab169d" name="Default" comment="">
+      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/js/pregnancyProgression.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/coc.html" afterPath="$PROJECT_DIR$/coc.html" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/appearance.js" afterPath="$PROJECT_DIR$/js/appearance.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/creature.js" afterPath="$PROJECT_DIR$/js/creature.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/flags/dataFlags.js" afterPath="$PROJECT_DIR$/js/flags/dataFlags.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/player.js" afterPath="$PROJECT_DIR$/js/player.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/pregnancy.js" afterPath="$PROJECT_DIR$/js/pregnancy.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/camp.js" afterPath="$PROJECT_DIR$/js/scenes/camp.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/combat.js" afterPath="$PROJECT_DIR$/js/scenes/combat.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/combatTeases.js" afterPath="$PROJECT_DIR$/js/scenes/combatTeases.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/npcs/amily.js" afterPath="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
+    </list>
     <ignored path="Corruption-of-Champions-HTML.iws" />
     <ignored path=".idea/workspace.xml" />
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
@@ -25,17 +38,198 @@
   </component>
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-      <file leaf-file-name="amily.js" pinned="false" current-in-tab="true">
+      <file leaf-file-name="amily.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="136">
-              <caret line="2799" column="81" selection-start-line="2799" selection-start-column="81" selection-end-line="2799" selection-end-column="81" />
+            <state relative-caret-position="-1147">
+              <caret line="32" column="0" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
               <folding>
                 <element signature="n#!!block;n#Amily#0" expanded="false" />
-                <element signature="e#294510#297653#0" expanded="false" />
-                <element signature="e#297714#298612#0" expanded="false" />
-                <element signature="e#327599#330651#0" expanded="false" />
+                <element signature="e#5184#5398#0" expanded="false" />
+                <element signature="e#5504#5599#0" expanded="false" />
+                <element signature="e#10958#11300#0" expanded="false" />
+                <element signature="e#11358#22487#0" expanded="false" />
+                <element signature="e#43453#51157#0" expanded="false" />
+                <element signature="e#51271#52125#0" expanded="false" />
+                <element signature="e#52283#53045#0" expanded="false" />
+                <element signature="e#53171#53463#0" expanded="false" />
+                <element signature="e#53622#54066#0" expanded="false" />
+                <element signature="e#54171#54677#0" expanded="false" />
+                <element signature="e#54993#55890#0" expanded="false" />
+                <element signature="e#56112#57554#0" expanded="false" />
+                <element signature="e#57671#59496#0" expanded="false" />
+                <element signature="e#59595#61206#0" expanded="false" />
+                <element signature="e#61318#63760#0" expanded="false" />
+                <element signature="e#63896#64477#0" expanded="false" />
+                <element signature="e#64612#66441#0" expanded="false" />
+                <element signature="e#66553#67729#0" expanded="false" />
+                <element signature="e#67839#69248#0" expanded="false" />
+                <element signature="e#69349#70021#0" expanded="false" />
+                <element signature="e#70239#71385#0" expanded="false" />
+                <element signature="e#74462#77481#0" expanded="false" />
+                <element signature="e#77571#79035#0" expanded="false" />
+                <element signature="e#79123#79742#0" expanded="false" />
+                <element signature="e#79828#80555#0" expanded="false" />
+                <element signature="e#80722#100763#0" expanded="false" />
+                <element signature="e#100908#103756#0" expanded="false" />
+                <element signature="e#103856#152745#0" expanded="false" />
+                <element signature="e#152830#159393#0" expanded="false" />
+                <element signature="e#159490#159568#0" expanded="false" />
+                <element signature="e#159740#163478#0" expanded="false" />
+                <element signature="e#163623#166715#0" expanded="false" />
+                <element signature="e#163625#163691#0" expanded="false" />
+                <element signature="e#164011#164465#0" expanded="false" />
+                <element signature="e#164591#166524#0" expanded="false" />
+                <element signature="e#166604#166712#0" expanded="false" />
+                <element signature="e#166829#173264#0" expanded="false" />
+                <element signature="e#326683#329735#0" expanded="false" />
               </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="appearance.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/appearance.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="3141">
+              <caret line="2364" column="12" selection-start-line="2364" selection-start-column="12" selection-end-line="2364" selection-end-column="12" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="creature.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/creature.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="-84">
+              <caret line="1318" column="47" selection-start-line="1318" selection-start-column="35" selection-end-line="1318" selection-end-column="47" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="player.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/player.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="245">
+              <caret line="1471" column="32" selection-start-line="1471" selection-start-column="32" selection-end-line="1471" selection-end-column="32" />
+              <folding>
+                <element signature="e#2456#7373#0" expanded="false" />
+                <element signature="e#7441#8055#0" expanded="false" />
+                <element signature="e#8123#8677#0" expanded="false" />
+                <element signature="e#8747#9348#0" expanded="false" />
+                <element signature="e#9490#10150#0" expanded="false" />
+                <element signature="e#10196#10691#0" expanded="false" />
+                <element signature="e#10755#11335#0" expanded="false" />
+                <element signature="e#11405#11782#0" expanded="false" />
+                <element signature="e#11845#12472#0" expanded="false" />
+                <element signature="e#12515#13045#0" expanded="false" />
+                <element signature="e#13090#13599#0" expanded="false" />
+                <element signature="e#13663#14362#0" expanded="false" />
+                <element signature="e#14426#15092#0" expanded="false" />
+                <element signature="e#15162#15661#0" expanded="false" />
+                <element signature="e#15705#16102#0" expanded="false" />
+                <element signature="e#16170#16665#0" expanded="false" />
+                <element signature="e#16737#18894#0" expanded="false" />
+                <element signature="e#18964#19984#0" expanded="false" />
+                <element signature="e#20042#20622#0" expanded="false" />
+                <element signature="e#20674#21034#0" expanded="false" />
+                <element signature="e#21088#21410#0" expanded="false" />
+                <element signature="e#21466#22192#0" expanded="false" />
+                <element signature="e#22248#22762#0" expanded="false" />
+                <element signature="e#22818#23249#0" expanded="false" />
+                <element signature="e#23305#23712#0" expanded="false" />
+                <element signature="e#23782#24860#0" expanded="false" />
+                <element signature="e#24915#25343#0" expanded="false" />
+                <element signature="e#25384#25780#0" expanded="false" />
+                <element signature="e#25823#26354#0" expanded="false" />
+                <element signature="e#26397#26897#0" expanded="false" />
+                <element signature="e#26942#27559#0" expanded="false" />
+                <element signature="e#27601#28224#0" expanded="false" />
+                <element signature="e#28281#28877#0" expanded="false" />
+                <element signature="e#28936#29809#0" expanded="false" />
+                <element signature="e#29863#34025#0" expanded="false" />
+                <element signature="e#43620#44374#0" expanded="false" />
+                <element signature="e#44443#44568#0" expanded="false" />
+                <element signature="e#44642#44819#0" expanded="false" />
+                <element signature="e#44893#45139#0" expanded="false" />
+                <element signature="e#45202#53510#0" expanded="false" />
+                <element signature="e#53564#53676#0" expanded="false" />
+                <element signature="e#53735#53756#0" expanded="false" />
+                <element signature="e#53799#53820#0" expanded="false" />
+                <element signature="e#53880#53884#0" expanded="false" />
+                <element signature="e#53935#54011#0" expanded="false" />
+                <element signature="e#54062#54228#0" expanded="false" />
+                <element signature="e#54280#54439#0" expanded="false" />
+                <element signature="e#54497#54594#0" expanded="false" />
+                <element signature="e#54641#54806#0" expanded="false" />
+                <element signature="e#54863#55054#0" expanded="false" />
+                <element signature="e#55096#55291#0" expanded="false" />
+                <element signature="e#55733#55773#0" expanded="false" />
+                <element signature="e#55826#55866#0" expanded="false" />
+                <element signature="e#55913#56076#0" expanded="false" />
+                <element signature="e#56125#56322#0" expanded="false" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="time.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/engine/time.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="173">
+              <caret line="36" column="22" selection-start-line="36" selection-start-column="22" selection-end-line="36" selection-end-column="22" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="pregnancyProgression.js" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="210">
+              <caret line="13" column="8" selection-start-line="13" selection-start-column="8" selection-end-line="13" selection-end-column="8" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="pregnancy.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/pregnancy.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="-195">
+              <caret line="131" column="53" selection-start-line="131" selection-start-column="53" selection-end-line="131" selection-end-column="53" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="camp.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="525">
+              <caret line="62" column="75" selection-start-line="62" selection-start-column="75" selection-end-line="62" selection-end-column="75" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="lake.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/scenes/areas/lake.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="555">
+              <caret line="37" column="18" selection-start-line="37" selection-start-column="18" selection-end-line="37" selection-end-column="18" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="dataFlags.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="150">
+              <caret line="10" column="98" selection-start-line="10" selection-start-column="98" selection-end-line="10" selection-end-column="98" />
+              <folding />
             </state>
           </provider>
         </entry>
@@ -62,9 +256,6 @@
   <component name="IdeDocumentHistory">
     <option name="CHANGED_PATHS">
       <list>
-        <option value="$PROJECT_DIR$/js/scenes/combat.js" />
-        <option value="$PROJECT_DIR$/js/scenes/areas/lake/gooGirl.js" />
-        <option value="$PROJECT_DIR$/js/scenes/places/farm/marble.js" />
         <option value="$PROJECT_DIR$/coc.css" />
         <option value="$PROJECT_DIR$/js/scenes/areas/lake/callu.js" />
         <option value="$PROJECT_DIR$/js/scenes/areas/forest/tentacleBeast.js" />
@@ -79,11 +270,9 @@
         <option value="$PROJECT_DIR$/js/scenes/masturbations.js" />
         <option value="$PROJECT_DIR$/js/cockClass.js" />
         <option value="$PROJECT_DIR$/js/vaginaClass.js" />
-        <option value="$PROJECT_DIR$/js/appearance.js" />
         <option value="$PROJECT_DIR$/js/scenes/npcs/lumi.js" />
         <option value="$PROJECT_DIR$/js/items/specialConsumables/reducto.js" />
         <option value="$PROJECT_DIR$/js/perkLib.js" />
-        <option value="$PROJECT_DIR$/js/player.js" />
         <option value="$PROJECT_DIR$/js/items/specialConsumables/oviElixir.js" />
         <option value="$PROJECT_DIR$/js/items/transformations.js" />
         <option value="$PROJECT_DIR$/js/engine/input.js" />
@@ -99,20 +288,25 @@
         <option value="$PROJECT_DIR$/js/globalVariables.js" />
         <option value="$PROJECT_DIR$/js/scenes/npcs/rathazul.js" />
         <option value="$PROJECT_DIR$/js/engine/time.js" />
-        <option value="$PROJECT_DIR$/js/pregnancy.js" />
-        <option value="$PROJECT_DIR$/js/scenes/camp.js" />
         <option value="$PROJECT_DIR$/js/items/consumables.js" />
         <option value="$PROJECT_DIR$/js/items/keyItems.js" />
         <option value="$PROJECT_DIR$/js/keyItemClass.js" />
-        <option value="$PROJECT_DIR$/coc.html" />
         <option value="$PROJECT_DIR$/js/scenes/places/townruins.js" />
         <option value="$PROJECT_DIR$/js/engine/utils.js" />
         <option value="$PROJECT_DIR$/js/engine/saves.js" />
         <option value="$PROJECT_DIR$/js/scenes/inventory.js" />
         <option value="$PROJECT_DIR$/js/keyItemLib.js" />
-        <option value="$PROJECT_DIR$/js/creature.js" />
+        <option value="$PROJECT_DIR$/js/pregnancy.js" />
+        <option value="$PROJECT_DIR$/js/player.js" />
+        <option value="$PROJECT_DIR$/js/scenes/combatTeases.js" />
         <option value="$PROJECT_DIR$/js/flags/dataFlags.js" />
+        <option value="$PROJECT_DIR$/js/scenes/combat.js" />
+        <option value="$PROJECT_DIR$/js/creature.js" />
+        <option value="$PROJECT_DIR$/js/scenes/camp.js" />
+        <option value="$PROJECT_DIR$/js/appearance.js" />
         <option value="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
+        <option value="$PROJECT_DIR$/coc.html" />
+        <option value="$PROJECT_DIR$/js/pregnancyProgression.js" />
       </list>
     </option>
   </component>
@@ -180,31 +374,183 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
+      <pane id="ProjectPane">
+        <subPane>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="js" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="js" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="scenes" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="js" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="scenes" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="npcs" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="js" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="scenes" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="monsters" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="js" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="scenes" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="areas" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="js" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="flags" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="Corruption-of-Champions-HTML" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="js" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="engine" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+        </subPane>
+      </pane>
       <pane id="Scope" />
       <pane id="Scratches" />
-      <pane id="ProjectPane">
-        <subPane />
-      </pane>
     </panes>
   </component>
   <component name="PropertiesComponent">
-    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="last_opened_file_path" value="$USER_HOME$/Downloads/Corruption-of-Champions-Mod-master/classes/classes/Monster.as" />
     <property name="WebServerToolWindowFactoryState" value="false" />
     <property name="HbShouldOpenHtmlAsHb" value="" />
     <property name="settings.editor.selected.configurable" value="preferences.editor" />
     <property name="settings.editor.splitter.proportion" value="0.2" />
     <property name="jsx.switch.disabled" value="true" />
     <property name="DefaultHtmlFileTemplate" value="HTML File" />
+    <property name="SearchEverywhereHistoryKey" value="&#9;FILE&#9;file:///home/sudhamma/Projects/Corruption-of-Champions-HTML/js/scenes/npcs/amily.js" />
   </component>
   <component name="RecentsManager">
-    <key name="CopyFile.RECENT_KEYS">
-      <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\sprites" />
-      <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\interface" />
-    </key>
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\sprites" />
       <recent name="G:\Sylvain\Data Files\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\js\scenes" />
       <recent name="G:\Sylvain\Data Files\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\js" />
+    </key>
+    <key name="CopyFile.RECENT_KEYS">
+      <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\sprites" />
+      <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\interface" />
     </key>
   </component>
   <component name="RunManager" selected="JavaScript Debug.coc.html">
@@ -300,6 +646,9 @@
       <workItem from="1466708239359" duration="1746000" />
       <workItem from="1466816770719" duration="22451000" />
       <workItem from="1466946857377" duration="28680000" />
+      <workItem from="1467063180164" duration="8158000" />
+      <workItem from="1467285999679" duration="3444000" />
+      <workItem from="1467421291015" duration="10128000" />
     </task>
     <task id="LOCAL-00001" summary="Release of 0.1 alpha with many more core content!&#10;&#10;Now with explorable zones, followers, etc!">
       <created>1455694082885</created>
@@ -326,7 +675,7 @@
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="89562000" />
+    <option name="totallyTimeSpent" value="111292000" />
   </component>
   <component name="TodoView" selected-index="4">
     <todo-panel id="selected-file">
@@ -341,22 +690,22 @@
     <frame x="0" y="27" width="1366" height="741" extended-state="6" />
     <editor active="true" />
     <layout>
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.24158126" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.24158126" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
       <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32854864" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
-      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
-      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.3891547" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="9" side_tool="false" content_ui="tabs" />
       <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="8" side_tool="false" content_ui="tabs" />
       <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="true" content_ui="tabs" />
-      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.36204147" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.36204147" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="Cvs" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
       <window_info id="Messages" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
       <window_info id="Commander" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.3891547" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
       <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.24963397" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
     </layout>
     <layout-to-restore>
@@ -406,74 +755,11 @@
           <properties />
         </breakpoint>
       </default-breakpoints>
-      <option name="time" value="34" />
+      <option name="time" value="47" />
     </breakpoint-manager>
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/js/vaginaClass.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="14" column="1" selection-start-line="14" selection-start-column="1" selection-end-line="14" selection-end-column="1" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/exploration.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="57" column="25" selection-start-line="57" selection-start-column="25" selection-end-line="57" selection-end-column="25" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/items/specialConsumables/reducto.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="7" column="1" selection-start-line="7" selection-start-column="1" selection-end-line="7" selection-end-column="1" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/perkLib.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="18" column="64" selection-start-line="18" selection-start-column="64" selection-end-line="18" selection-end-column="64" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/npcs/lumi.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="90" column="40" selection-start-line="90" selection-start-column="40" selection-end-line="90" selection-end-column="40" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/items/specialConsumables/oviElixir.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="2" column="52" selection-start-line="2" selection-start-column="52" selection-end-line="2" selection-end-column="52" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/text.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="13" column="0" selection-start-line="13" selection-start-column="0" selection-end-line="13" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/appearance.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="1877" column="125" selection-start-line="1877" selection-start-column="125" selection-end-line="1877" selection-end-column="125" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/playerInfo.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="1552" column="6" selection-start-line="1552" selection-start-column="6" selection-end-line="1552" selection-end-column="6" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/js/scenes/places/farm.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="0">
@@ -531,13 +817,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/areas/lake.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-410">
-          <caret line="37" column="18" selection-start-line="37" selection-start-column="18" selection-end-line="37" selection-end-column="18" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/assets/sprites/jojo.png">
       <provider selected="true" editor-type-id="images">
         <state />
@@ -562,20 +841,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/monsters/imp.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-405">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/monsters/goblin.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-75">
-          <caret line="44" column="16" selection-start-line="44" selection-start-column="16" selection-end-line="44" selection-end-column="16" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/js/engine/gui.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="730">
@@ -587,15 +852,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="165">
           <caret line="11" column="24" selection-start-line="11" selection-start-column="24" selection-end-line="11" selection-end-column="24" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/time.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="525">
-          <caret line="36" column="22" selection-start-line="36" selection-start-column="22" selection-end-line="36" selection-end-column="22" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -603,31 +859,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="93">
           <caret line="94" column="50" selection-start-line="94" selection-start-column="50" selection-end-line="94" selection-end-column="50" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="810">
-          <caret line="54" column="4" selection-start-line="54" selection-start-column="4" selection-end-line="54" selection-end-column="4" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/combat.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="106">
-          <caret line="391" column="131" selection-start-line="391" selection-start-column="125" selection-end-line="391" selection-end-column="131" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/items/weapons.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -635,31 +866,14 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="277">
           <caret line="84" column="13" selection-start-line="84" selection-start-column="13" selection-end-line="84" selection-end-column="13" />
-          <folding />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/items/keyItems.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="121" selection-start-line="0" selection-start-column="121" selection-end-line="0" selection-end-column="121" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/coc.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="120">
-          <caret line="104" column="71" selection-start-line="104" selection-start-column="71" selection-end-line="104" selection-end-column="71" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
+    <entry file="file://$PROJECT_DIR$/js/items/keyItems.js" />
     <entry file="file://$PROJECT_DIR$/js/itemClass.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="1350">
           <caret line="90" column="5" selection-start-line="90" selection-start-column="5" selection-end-line="90" selection-end-column="5" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -667,7 +881,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="330">
           <caret line="19" column="1" selection-start-line="19" selection-start-column="1" selection-end-line="19" selection-end-column="1" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -675,7 +888,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="111">
           <caret line="169" column="25" selection-start-line="169" selection-start-column="18" selection-end-line="169" selection-end-column="25" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -689,19 +901,10 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/pregnancy.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="653">
-          <caret line="125" column="65" selection-start-line="125" selection-start-column="65" selection-end-line="125" selection-end-column="65" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/js/engine/saves.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="-1540">
           <caret line="158" column="73" selection-start-line="158" selection-start-column="73" selection-end-line="158" selection-end-column="73" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -709,7 +912,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="188">
           <caret line="77" column="21" selection-start-line="77" selection-start-column="11" selection-end-line="77" selection-end-column="21" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -717,7 +919,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="520">
           <caret line="37" column="59" selection-start-line="37" selection-start-column="59" selection-end-line="37" selection-end-column="59" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -725,7 +926,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="262">
           <caret line="94" column="22" selection-start-line="94" selection-start-column="22" selection-end-line="94" selection-end-column="22" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -733,31 +933,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="210">
           <caret line="14" column="20" selection-start-line="14" selection-start-column="9" selection-end-line="14" selection-end-column="20" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/scenes/inventory.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="220">
-          <caret line="118" column="18" selection-start-line="118" selection-start-column="16" selection-end-line="118" selection-end-column="18" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/creature.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="15">
-          <caret line="751" column="10" selection-start-line="751" selection-start-column="10" selection-end-line="751" selection-end-column="10" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/js/player.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="30">
-          <caret line="2" column="13" selection-start-line="2" selection-start-column="8" selection-end-line="2" selection-end-column="13" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -765,7 +940,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="187">
           <caret line="25" column="64" selection-start-line="25" selection-start-column="57" selection-end-line="25" selection-end-column="64" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -777,24 +951,278 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/js/items/weapons.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/inventory.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1800">
+          <caret line="120" column="66" selection-start-line="120" selection-start-column="60" selection-end-line="120" selection-end-column="66" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/statusEffectLib.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="210">
+          <caret line="14" column="34" selection-start-line="14" selection-start-column="33" selection-end-line="14" selection-end-column="34" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/perkLib.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="345">
+          <caret line="18" column="64" selection-start-line="18" selection-start-column="64" selection-end-line="18" selection-end-column="64" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/monsters/imp.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/Downloads/Corruption-of-Champions-Mod-master/classes/classes/Monster.as">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="106">
+          <caret line="593" column="36" selection-start-line="593" selection-start-column="24" selection-end-line="593" selection-end-column="36" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/Downloads/Corruption-of-Champions-Mod-master/classes/classes/Scenes/Combat/CombatAbilities.as">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="106">
+          <caret line="887" column="19" selection-start-line="887" selection-start-column="14" selection-end-line="887" selection-end-column="19" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/Downloads/Corruption-of-Champions-Mod-master/classes/classes/Scenes/Combat/Combat.as">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="106">
+          <caret line="707" column="33" selection-start-line="707" selection-start-column="28" selection-end-line="707" selection-end-column="33" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/exploration.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-244">
+          <caret line="57" column="25" selection-start-line="57" selection-start-column="25" selection-end-line="57" selection-end-column="25" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/combatTeases.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="5439">
+          <caret line="1367" column="17" selection-start-line="1367" selection-start-column="17" selection-end-line="1367" selection-end-column="17" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/monsters/goblin.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="150">
+          <caret line="10" column="24" selection-start-line="7" selection-start-column="4" selection-end-line="10" selection-end-column="24" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/combat.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="66">
+          <caret line="39" column="12" selection-start-line="39" selection-start-column="11" selection-end-line="39" selection-end-column="12" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/areas/lake.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="555">
+          <caret line="37" column="18" selection-start-line="37" selection-start-column="18" selection-end-line="37" selection-end-column="18" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/js/flags/dataFlags.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="300">
-          <caret line="113" column="63" selection-start-line="113" selection-start-column="63" selection-end-line="113" selection-end-column="63" />
+        <state relative-caret-position="150">
+          <caret line="10" column="98" selection-start-line="10" selection-start-column="98" selection-end-line="10" selection-end-column="98" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/scenes/camp.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="525">
+          <caret line="62" column="75" selection-start-line="62" selection-start-column="75" selection-end-line="62" selection-end-column="75" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/creature.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-84">
+          <caret line="1318" column="47" selection-start-line="1318" selection-start-column="35" selection-end-line="1318" selection-end-column="47" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/appearance.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="3141">
+          <caret line="2364" column="12" selection-start-line="2364" selection-start-column="12" selection-end-line="2364" selection-end-column="12" />
           <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="136">
-          <caret line="2799" column="81" selection-start-line="2799" selection-start-column="81" selection-end-line="2799" selection-end-column="81" />
+        <state relative-caret-position="-1147">
+          <caret line="32" column="0" selection-start-line="32" selection-start-column="0" selection-end-line="32" selection-end-column="0" />
           <folding>
             <element signature="n#!!block;n#Amily#0" expanded="false" />
-            <element signature="e#294510#297653#0" expanded="false" />
-            <element signature="e#297714#298612#0" expanded="false" />
-            <element signature="e#327599#330651#0" expanded="false" />
+            <element signature="e#5184#5398#0" expanded="false" />
+            <element signature="e#5504#5599#0" expanded="false" />
+            <element signature="e#10958#11300#0" expanded="false" />
+            <element signature="e#11358#22487#0" expanded="false" />
+            <element signature="e#43453#51157#0" expanded="false" />
+            <element signature="e#51271#52125#0" expanded="false" />
+            <element signature="e#52283#53045#0" expanded="false" />
+            <element signature="e#53171#53463#0" expanded="false" />
+            <element signature="e#53622#54066#0" expanded="false" />
+            <element signature="e#54171#54677#0" expanded="false" />
+            <element signature="e#54993#55890#0" expanded="false" />
+            <element signature="e#56112#57554#0" expanded="false" />
+            <element signature="e#57671#59496#0" expanded="false" />
+            <element signature="e#59595#61206#0" expanded="false" />
+            <element signature="e#61318#63760#0" expanded="false" />
+            <element signature="e#63896#64477#0" expanded="false" />
+            <element signature="e#64612#66441#0" expanded="false" />
+            <element signature="e#66553#67729#0" expanded="false" />
+            <element signature="e#67839#69248#0" expanded="false" />
+            <element signature="e#69349#70021#0" expanded="false" />
+            <element signature="e#70239#71385#0" expanded="false" />
+            <element signature="e#74462#77481#0" expanded="false" />
+            <element signature="e#77571#79035#0" expanded="false" />
+            <element signature="e#79123#79742#0" expanded="false" />
+            <element signature="e#79828#80555#0" expanded="false" />
+            <element signature="e#80722#100763#0" expanded="false" />
+            <element signature="e#100908#103756#0" expanded="false" />
+            <element signature="e#103856#152745#0" expanded="false" />
+            <element signature="e#152830#159393#0" expanded="false" />
+            <element signature="e#159490#159568#0" expanded="false" />
+            <element signature="e#159740#163478#0" expanded="false" />
+            <element signature="e#163623#166715#0" expanded="false" />
+            <element signature="e#163625#163691#0" expanded="false" />
+            <element signature="e#164011#164465#0" expanded="false" />
+            <element signature="e#164591#166524#0" expanded="false" />
+            <element signature="e#166604#166712#0" expanded="false" />
+            <element signature="e#166829#173264#0" expanded="false" />
+            <element signature="e#326683#329735#0" expanded="false" />
           </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/time.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="173">
+          <caret line="36" column="22" selection-start-line="36" selection-start-column="22" selection-end-line="36" selection-end-column="22" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/coc.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="118">
+          <caret line="98" column="72" selection-start-line="98" selection-start-column="72" selection-end-line="98" selection-end-column="72" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/pregnancy.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-195">
+          <caret line="131" column="53" selection-start-line="131" selection-start-column="53" selection-end-line="131" selection-end-column="53" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/player.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="245">
+          <caret line="1471" column="32" selection-start-line="1471" selection-start-column="32" selection-end-line="1471" selection-end-column="32" />
+          <folding>
+            <element signature="e#2456#7373#0" expanded="false" />
+            <element signature="e#7441#8055#0" expanded="false" />
+            <element signature="e#8123#8677#0" expanded="false" />
+            <element signature="e#8747#9348#0" expanded="false" />
+            <element signature="e#9490#10150#0" expanded="false" />
+            <element signature="e#10196#10691#0" expanded="false" />
+            <element signature="e#10755#11335#0" expanded="false" />
+            <element signature="e#11405#11782#0" expanded="false" />
+            <element signature="e#11845#12472#0" expanded="false" />
+            <element signature="e#12515#13045#0" expanded="false" />
+            <element signature="e#13090#13599#0" expanded="false" />
+            <element signature="e#13663#14362#0" expanded="false" />
+            <element signature="e#14426#15092#0" expanded="false" />
+            <element signature="e#15162#15661#0" expanded="false" />
+            <element signature="e#15705#16102#0" expanded="false" />
+            <element signature="e#16170#16665#0" expanded="false" />
+            <element signature="e#16737#18894#0" expanded="false" />
+            <element signature="e#18964#19984#0" expanded="false" />
+            <element signature="e#20042#20622#0" expanded="false" />
+            <element signature="e#20674#21034#0" expanded="false" />
+            <element signature="e#21088#21410#0" expanded="false" />
+            <element signature="e#21466#22192#0" expanded="false" />
+            <element signature="e#22248#22762#0" expanded="false" />
+            <element signature="e#22818#23249#0" expanded="false" />
+            <element signature="e#23305#23712#0" expanded="false" />
+            <element signature="e#23782#24860#0" expanded="false" />
+            <element signature="e#24915#25343#0" expanded="false" />
+            <element signature="e#25384#25780#0" expanded="false" />
+            <element signature="e#25823#26354#0" expanded="false" />
+            <element signature="e#26397#26897#0" expanded="false" />
+            <element signature="e#26942#27559#0" expanded="false" />
+            <element signature="e#27601#28224#0" expanded="false" />
+            <element signature="e#28281#28877#0" expanded="false" />
+            <element signature="e#28936#29809#0" expanded="false" />
+            <element signature="e#29863#34025#0" expanded="false" />
+            <element signature="e#43620#44374#0" expanded="false" />
+            <element signature="e#44443#44568#0" expanded="false" />
+            <element signature="e#44642#44819#0" expanded="false" />
+            <element signature="e#44893#45139#0" expanded="false" />
+            <element signature="e#45202#53510#0" expanded="false" />
+            <element signature="e#53564#53676#0" expanded="false" />
+            <element signature="e#53735#53756#0" expanded="false" />
+            <element signature="e#53799#53820#0" expanded="false" />
+            <element signature="e#53880#53884#0" expanded="false" />
+            <element signature="e#53935#54011#0" expanded="false" />
+            <element signature="e#54062#54228#0" expanded="false" />
+            <element signature="e#54280#54439#0" expanded="false" />
+            <element signature="e#54497#54594#0" expanded="false" />
+            <element signature="e#54641#54806#0" expanded="false" />
+            <element signature="e#54863#55054#0" expanded="false" />
+            <element signature="e#55096#55291#0" expanded="false" />
+            <element signature="e#55733#55773#0" expanded="false" />
+            <element signature="e#55826#55866#0" expanded="false" />
+            <element signature="e#55913#56076#0" expanded="false" />
+            <element signature="e#56125#56322#0" expanded="false" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="210">
+          <caret line="13" column="8" selection-start-line="13" selection-start-column="8" selection-end-line="13" selection-end-column="8" />
+          <folding />
         </state>
       </provider>
     </entry>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,18 +6,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="8a292ce1-df00-4848-8a40-d7241dab169d" name="Default" comment="">
-      <change type="NEW" beforePath="" afterPath="$PROJECT_DIR$/js/pregnancyProgression.js" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/.idea/workspace.xml" afterPath="$PROJECT_DIR$/.idea/workspace.xml" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/coc.html" afterPath="$PROJECT_DIR$/coc.html" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/appearance.js" afterPath="$PROJECT_DIR$/js/appearance.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/creature.js" afterPath="$PROJECT_DIR$/js/creature.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/flags/dataFlags.js" afterPath="$PROJECT_DIR$/js/flags/dataFlags.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/player.js" afterPath="$PROJECT_DIR$/js/player.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/pregnancy.js" afterPath="$PROJECT_DIR$/js/pregnancy.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/camp.js" afterPath="$PROJECT_DIR$/js/scenes/camp.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/combat.js" afterPath="$PROJECT_DIR$/js/scenes/combat.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/combatTeases.js" afterPath="$PROJECT_DIR$/js/scenes/combatTeases.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/npcs/amily.js" afterPath="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/pregnancyProgression.js" afterPath="$PROJECT_DIR$/js/pregnancyProgression.js" />
     </list>
     <ignored path="Corruption-of-Champions-HTML.iws" />
     <ignored path=".idea/workspace.xml" />
@@ -111,8 +101,8 @@
       <file leaf-file-name="player.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/js/player.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="245">
-              <caret line="1471" column="32" selection-start-line="1471" selection-start-column="32" selection-end-line="1471" selection-end-column="32" />
+            <state relative-caret-position="111">
+              <caret line="1111" column="32" selection-start-line="1111" selection-start-column="30" selection-end-line="1111" selection-end-column="32" />
               <folding>
                 <element signature="e#2456#7373#0" expanded="false" />
                 <element signature="e#7441#8055#0" expanded="false" />
@@ -148,7 +138,6 @@
                 <element signature="e#27601#28224#0" expanded="false" />
                 <element signature="e#28281#28877#0" expanded="false" />
                 <element signature="e#28936#29809#0" expanded="false" />
-                <element signature="e#29863#34025#0" expanded="false" />
                 <element signature="e#43620#44374#0" expanded="false" />
                 <element signature="e#44443#44568#0" expanded="false" />
                 <element signature="e#44642#44819#0" expanded="false" />
@@ -187,8 +176,8 @@
       <file leaf-file-name="pregnancyProgression.js" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="210">
-              <caret line="13" column="8" selection-start-line="13" selection-start-column="8" selection-end-line="13" selection-end-column="8" />
+            <state relative-caret-position="195">
+              <caret line="12" column="2" selection-start-line="12" selection-start-column="2" selection-end-line="12" selection-end-column="2" />
               <folding />
             </state>
           </provider>
@@ -209,16 +198,6 @@
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="525">
               <caret line="62" column="75" selection-start-line="62" selection-start-column="75" selection-end-line="62" selection-end-column="75" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="lake.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/js/scenes/areas/lake.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="555">
-              <caret line="37" column="18" selection-start-line="37" selection-start-column="18" selection-end-line="37" selection-end-column="18" />
               <folding />
             </state>
           </provider>
@@ -256,7 +235,6 @@
   <component name="IdeDocumentHistory">
     <option name="CHANGED_PATHS">
       <list>
-        <option value="$PROJECT_DIR$/coc.css" />
         <option value="$PROJECT_DIR$/js/scenes/areas/lake/callu.js" />
         <option value="$PROJECT_DIR$/js/scenes/areas/forest/tentacleBeast.js" />
         <option value="$PROJECT_DIR$/js/scenes/intro.js" />
@@ -306,6 +284,7 @@
         <option value="$PROJECT_DIR$/js/appearance.js" />
         <option value="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
         <option value="$PROJECT_DIR$/coc.html" />
+        <option value="$PROJECT_DIR$/js/pp.js" />
         <option value="$PROJECT_DIR$/js/pregnancyProgression.js" />
       </list>
     </option>
@@ -549,6 +528,7 @@
       <recent name="G:\Sylvain\Data Files\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\js" />
     </key>
     <key name="CopyFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/js" />
       <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\sprites" />
       <recent name="C:\Users\Sylvain\Documents\Corruption_of_Champions\Corruption-of-Champions-HTML\assets\interface" />
     </key>
@@ -648,7 +628,7 @@
       <workItem from="1466946857377" duration="28680000" />
       <workItem from="1467063180164" duration="8158000" />
       <workItem from="1467285999679" duration="3444000" />
-      <workItem from="1467421291015" duration="10128000" />
+      <workItem from="1467421291015" duration="11309000" />
     </task>
     <task id="LOCAL-00001" summary="Release of 0.1 alpha with many more core content!&#10;&#10;Now with explorable zones, followers, etc!">
       <created>1455694082885</created>
@@ -675,7 +655,7 @@
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="111292000" />
+    <option name="totallyTimeSpent" value="112473000" />
   </component>
   <component name="TodoView" selected-index="4">
     <todo-panel id="selected-file">
@@ -693,6 +673,7 @@
       <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.24158126" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
       <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32854864" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="9" side_tool="false" content_ui="tabs" />
       <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
@@ -705,7 +686,6 @@
       <window_info id="Commander" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
       <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.3891547" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
       <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.24963397" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
-      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32861635" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
     </layout>
     <layout-to-restore>
@@ -760,13 +740,6 @@
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/js/scenes/places/farm.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="15" column="29" selection-start-line="15" selection-start-column="29" selection-end-line="15" selection-end-column="29" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/js/scenes/places/farm/whitney.js">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="0">
@@ -1130,14 +1103,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/js/engine/time.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="173">
-          <caret line="36" column="22" selection-start-line="36" selection-start-column="22" selection-end-line="36" selection-end-column="22" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/coc.html">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="118">
@@ -1154,10 +1119,18 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/js/engine/time.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="173">
+          <caret line="36" column="22" selection-start-line="36" selection-start-column="22" selection-end-line="36" selection-end-column="22" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/js/player.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="245">
-          <caret line="1471" column="32" selection-start-line="1471" selection-start-column="32" selection-end-line="1471" selection-end-column="32" />
+        <state relative-caret-position="111">
+          <caret line="1111" column="32" selection-start-line="1111" selection-start-column="30" selection-end-line="1111" selection-end-column="32" />
           <folding>
             <element signature="e#2456#7373#0" expanded="false" />
             <element signature="e#7441#8055#0" expanded="false" />
@@ -1193,7 +1166,6 @@
             <element signature="e#27601#28224#0" expanded="false" />
             <element signature="e#28281#28877#0" expanded="false" />
             <element signature="e#28936#29809#0" expanded="false" />
-            <element signature="e#29863#34025#0" expanded="false" />
             <element signature="e#43620#44374#0" expanded="false" />
             <element signature="e#44443#44568#0" expanded="false" />
             <element signature="e#44642#44819#0" expanded="false" />
@@ -1218,10 +1190,18 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/js/pp.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/js/pregnancyProgression.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="210">
-          <caret line="13" column="8" selection-start-line="13" selection-start-column="8" selection-end-line="13" selection-end-column="8" />
+        <state relative-caret-position="195">
+          <caret line="12" column="2" selection-start-line="12" selection-start-column="2" selection-end-line="12" selection-end-column="2" />
           <folding />
         </state>
       </provider>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,11 +5,7 @@
     <option name="SCOPE_TYPE" value="3" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="8a292ce1-df00-4848-8a40-d7241dab169d" name="Default" comment="">
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/flags/dataFlags.js" afterPath="$PROJECT_DIR$/js/flags/dataFlags.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/keyItemLib.js" afterPath="$PROJECT_DIR$/js/keyItemLib.js" />
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/js/scenes/npcs/amily.js" afterPath="$PROJECT_DIR$/js/scenes/npcs/amily.js" />
-    </list>
+    <list default="true" id="8a292ce1-df00-4848-8a40-d7241dab169d" name="Default" comment="" />
     <ignored path="Corruption-of-Champions-HTML.iws" />
     <ignored path=".idea/workspace.xml" />
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
@@ -32,8 +28,8 @@
       <file leaf-file-name="amily.js" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="196">
-              <caret line="2803" column="13" selection-start-line="2803" selection-start-column="13" selection-end-line="2803" selection-end-column="13" />
+            <state relative-caret-position="136">
+              <caret line="2799" column="81" selection-start-line="2799" selection-start-column="81" selection-end-line="2799" selection-end-column="81" />
               <folding>
                 <element signature="n#!!block;n#Amily#0" expanded="false" />
                 <element signature="e#294510#297653#0" expanded="false" />
@@ -303,7 +299,7 @@
       <workItem from="1466623378417" duration="1698000" />
       <workItem from="1466708239359" duration="1746000" />
       <workItem from="1466816770719" duration="22451000" />
-      <workItem from="1466946857377" duration="28628000" />
+      <workItem from="1466946857377" duration="28680000" />
     </task>
     <task id="LOCAL-00001" summary="Release of 0.1 alpha with many more core content!&#10;&#10;Now with explorable zones, followers, etc!">
       <created>1455694082885</created>
@@ -330,7 +326,7 @@
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="89510000" />
+    <option name="totallyTimeSpent" value="89562000" />
   </component>
   <component name="TodoView" selected-index="4">
     <todo-panel id="selected-file">
@@ -791,8 +787,8 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/js/scenes/npcs/amily.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="196">
-          <caret line="2803" column="13" selection-start-line="2803" selection-start-column="13" selection-end-line="2803" selection-end-column="13" />
+        <state relative-caret-position="136">
+          <caret line="2799" column="81" selection-start-line="2799" selection-start-column="81" selection-end-line="2799" selection-end-column="81" />
           <folding>
             <element signature="n#!!block;n#Amily#0" expanded="false" />
             <element signature="e#294510#297653#0" expanded="false" />

--- a/coc.html
+++ b/coc.html
@@ -96,6 +96,7 @@
 		<script type="text/javascript" src="js/appearance.js"></script>
 		<script type="text/javascript" src="js/assClass.js"></script>
         <script type="text/javascript" src="js/pregnancy.js"></script>
+		<script type="text/javascript" src="js/pregnancyProgression.js"></script>
 		<script type="text/javascript" src="js/breastRowClass.js"></script>
 		<script type="text/javascript" src="js/cockClass.js"></script>
 		<script type="text/javascript" src="js/vaginaClass.js"></script>

--- a/js/appearance.js
+++ b/js/appearance.js
@@ -2361,7 +2361,7 @@ Appearance.biggestBreastSizeDescript = function(creature) {
     }
     if (creature.breastRows[temp142].breastRating < 1) return "flat breasts";
     //50% of the time size-descript them
-    if (rand(2) == 0) descript += breastSize(creature.breastRows[temp142].breastRating);
+    if (rand(2) == 0) descript += Appearance.breastSize(creature.breastRows[temp142].breastRating);
     //Nouns!
     temp14 = rand(10);
     if (temp14 == 0) descript += "breasts";

--- a/js/creature.js
+++ b/js/creature.js
@@ -2488,7 +2488,7 @@ Creature.prototype.cuntChange = function(cArea, display, spacingsF, spacingsB) {
     return stretched;
 }
 Creature.prototype.cuntChangeNoDisplay = function(cArea) {
-    if (vaginas.length == 0) return false;
+    if (this.vaginas.length == 0) return false;
     var stretched = false;
     if (this.findPerk(PerkLib.FerasBoonMilkingTwat) < 0 || vaginas[0].vaginalLooseness <= VAGINA_LOOSENESS_NORMAL) {
         //cArea > capacity = autostreeeeetch.
@@ -2522,12 +2522,12 @@ Creature.prototype.cuntChangeNoDisplay = function(cArea) {
     return stretched;
 }
 Creature.prototype.cuntChangeDisplay = function() {
-    if (vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_CLOWN_CAR) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is stretched painfully wide, large enough to accomodate most beasts and demons.</b>");
-    if (vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_GAPING_WIDE) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is stretched so wide that it gapes continually.</b>");
-    if (vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_GAPING) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " painfully stretches, the lips now wide enough to gape slightly.</b>");
-    if (vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_LOOSE) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is now very loose.</b>", false);
-    if (vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_NORMAL) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is now a little loose.</b>", false);
-    if (vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_TIGHT) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is stretched out to a more normal size.</b>");
+    if (this.vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_CLOWN_CAR) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is stretched painfully wide, large enough to accomodate most beasts and demons.</b>");
+    if (this.vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_GAPING_WIDE) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is stretched so wide that it gapes continually.</b>");
+    if (this.vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_GAPING) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " painfully stretches, the lips now wide enough to gape slightly.</b>");
+    if (this.vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_LOOSE) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is now very loose.</b>", false);
+    if (this.vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_NORMAL) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is now a little loose.</b>", false);
+    if (this.vaginas[0].vaginalLooseness == VAGINA_LOOSENESS_TIGHT) outputText("<b>Your " + Appearance.vaginaDescript(this,0) + " is stretched out to a more normal size.</b>");
 }
 //Anal Stretching
 Creature.prototype.buttChange = function(cArea, display, spacingsF, spacingsB) {

--- a/js/engine/saves.js
+++ b/js/engine/saves.js
@@ -164,6 +164,23 @@ Data.saveGameObject = function(slot) {
             }
         }
 
+        //Player Pregnancy
+        saveData.player.pregnancyIncubation = player.pregnancyIncubation;
+        saveData.player.pregnancyType = player.pregnancyType;
+        saveData.player.pregnancyEventArr = player.pregnancyEventArr;
+        saveData.buttPregnancyIncubation = player.buttPregnancyIncubation;
+        saveData.buttPregnancyType = player.buttPregnancyType;
+        saveData.player.pregnancyEventNum = player.pregnancyEventNum;
+
+        //Amily Pregnancy
+        saveData.amilypregnancyIncubation = amily.pregnancyIncubation;
+        saveData.amilypregnancyType = amily.pregnancyType;
+        saveData.amilypregnancyEventArr = amily.pregnancyEventArr;
+        saveData.amilybuttPregnancyIncubation = amily.buttPregnancyIncubation;
+        saveData.amilybuttPregnancyType = amily.buttPregnancyType;
+        saveData.amilypregnancyEventNum = amily.pregnancyEventNum;
+
+
         //Spells
         saveData.player.spells = {};
         saveData.player.spells.chargeWeapon = player.spells.chargeWeapon;
@@ -187,10 +204,18 @@ Data.saveGameObject = function(slot) {
         saveData.time.hours = time.hours;
         saveData.time.minutes = time.minutes;
 
+        //Game Flags
         saveData.gameFlags = {};
         for (i in gameFlags) {
             saveData.gameFlags[i] = gameFlags[i];
         }
+
+        //Amily Save Test
+        //if (AmilyScene.pregnancy.pregnancyTypeFlag != 0) {
+        //    saveData.gameFlags[AMILY_PREGNANCY_TYPE] = AmilyScene.pregnancy.pregnancyTypeFlag;
+        //    saveData.gameFlags[AMILY_INCUBATION] = AmilyScene.pregnancy.pregnancyIncubationFlag;
+        //}
+
 
         //Assign Save Version
         saveData.saveVersion = saveVersion;
@@ -272,6 +297,25 @@ Data.loadGameObject = function(slot) {
             //player.createKeyItem(lookupKeyItem(saveData.player.keyItems[i].id), saveData.player.keyItems[i].value1, saveData.player.keyItems[i].value2, saveData.player.keyItems[i].value3, saveData.player.keyItems[i].value4);
         }
 
+        //Player Pregnancy Load
+        player.pregnancyIncubation = saveData.player.pregnancyIncubation;
+        player.pregnancyType = saveData.player.pregnancyType;
+        player.pregnancyEventArr = saveData.player.pregnancyEventArr;
+        player.buttPregnancyIncubation = saveData.player.buttPregnancyIncubation;
+        player.buttPregnancyType = saveData.player.buttPregnancyType;
+        player.pregnancyEventNum = saveData.player.pregnancyEventNum;
+
+        //Amily Pregnancy Load
+        amily.pregnancyIncubation = saveData.amilypregnancyIncubation;
+        amily.pregnancyType = saveData.amilypregnancyType;
+        amily.pregnancyEventArr = saveData.amilypregnancyEventArr;
+        amily.buttPregnancyIncubation = saveData.amilybuttPregnancyIncubation;
+        amily.buttPregnancyType = saveData.amilybuttPregnancyType;
+        amily.pregnancyEventNum = saveData.amilypregnancyEventNum;
+
+
+
+
         //Spells
         if (saveData.player.spells != undefined) {
             player.spells = [];
@@ -308,6 +352,15 @@ Data.loadGameObject = function(slot) {
                     gameFlags[i] = saveData.gameFlags[i];
             }
         }
+
+        /*
+        //Amily Test Load
+        if (saveData.amilyPregType != 0) {
+            AmilyScene.pregnancy.pregnancyTypeFlag = gameFlags[saveData.amilyPregType];
+            AmilyScene.pregnancy.pregnancyIncubationFlag = gameFlags[saveData.amilyPregDur];
+        };
+        */
+
         Data.fixSave();
 
         //Set to successful and return
@@ -359,6 +412,7 @@ Data.fixSave = function() {
     for (i in player.breastRows) {
         unfuckBreastRow(player.breastRows[i]);
     }
+    
 }
 
 //DELETE SAVE

--- a/js/engine/time.js
+++ b/js/engine/time.js
@@ -20,24 +20,20 @@ Time.increment = function() {
 
 
 Time.advanceMinutes = function(minutes) {
-	if (timeAware.length > 0) { // If there's a function in timeAware
-		for (i = 0; i < timeAware.length; i++) {
-			timeAware[i].advanceTime(minutes);
+	//if (timeAware.length > 0) { // If there's a function in timeAware
+	//	for (i = 0; i < timeAware.length; i++) {
+	//		timeAware[i].advanceTime(minutes);
 
-		}
+	//	}
 		for (i = 0; i < minutes; i++) {
 			Time.increment();
+			player.pregnancyAdvance(); // Advances the Player's pregnancy.
+			amily.pregnancyAdvance(); // Advances Amily's pregnancy.
 		}
-	}
+	pregnancyProgression.updatePregnancy(); // Outputs the results of the Player's pregnancy flags once time passes.
 }
 
 	Time.advanceHours = function (hours) {
-		//Feed the number of hours through a for loop and force advancement code
-		if (timeAware.length > 0) { // If there's a function in timeAware
-			for (i = 1; i < timeAware.length; i++) {
-				timeAware[i].advanceTime(hours * 60);
-				}
-		}
-        // Then advance the display clock
+
 		Time.advanceMinutes(hours * 60);
     }

--- a/js/engine/time.js
+++ b/js/engine/time.js
@@ -38,6 +38,6 @@ Time.advanceMinutes = function(minutes) {
 				timeAware[i].advanceTime(hours * 60);
 				}
 		}
+        // Then advance the display clock
 		Time.advanceMinutes(hours * 60);
-		// Then advance the display clock
-	}
+    }

--- a/js/flags/dataFlags.js
+++ b/js/flags/dataFlags.js
@@ -8,6 +8,7 @@
 //------------
 const TIMES_TRANSFORMED                 = "Times_Transformed";
 const TIMES_ORGASMED                    = "Times_Orgasmed";
+const PC_FETISH                         = "PC_Fetish"; // Used in lust attack in combatTeases file
 
 //------------
 // MISC
@@ -121,6 +122,7 @@ const AMILY_TREE_FLIPOUT                = "Amily_Tree_Flipout";
 
 const INCUBATION_MOUSE                  = 350; // Incubation time for mice types/Amily
 const PREGNANCY_PLAYER                  = "Player"; // Marks the player impregnated someone
+const PREGNANCY_AMILY                   = "Amily";
 
 //------------
 // ENCOUNTERS

--- a/js/flags/dataFlags.js
+++ b/js/flags/dataFlags.js
@@ -113,6 +113,13 @@ const CREATE_POTENT_MIXTURE        = "Amily_Drank_Potent_Mixture";
 const AMILY_BIRTH_TOTAL                 = "Amily_Birth_Total";
 const AMILY_CORRUPTION_PATH             = "Amily_Corruption_Path";
 const AMILY_TREE_FLIPOUT                = "Amily_Tree_Flipout";
+const AMILY_CUP_SIZE                    = "Amily_Cup_Size";
+const AMILY_NIPPLE_LENGTH               = "Amily_Nipple_Length";
+const AMILY_HIP_RATING                  = "Amily_Hip_Rating";
+const AMILY_ASS_SIZE                    = "Amily_Ass_Size";
+const AMILY_VAGINAL_WETNESS             = "Amily_Vaginal_Wetness";
+const AMILY_CLOTHING                    = "Amily_Clothing";
+
 
 //=================
 // PREGNANCY FLAGS
@@ -120,9 +127,19 @@ const AMILY_TREE_FLIPOUT                = "Amily_Tree_Flipout";
 // Note that these are actual constants, not called by gameFlags yet until the pregnancy system is figured out.
 //=================
 
+// Base incubation values
 const INCUBATION_MOUSE                  = 350; // Incubation time for mice types/Amily
+
+// Pregnancy event arrays
+const INCUBATION_MOUSE_EVENT            = [336, 280, 216, 180, 120, 72, 48, 32]; // Event flags for Mouse Pregnancy
+const INCUBATION_AMILY_EVENT            = [150, 120, 100, 96, 90, 72, 48]; // Special array for Amily pregnancy in Town Ruins.
+
+// Pregnancy Flags
 const PREGNANCY_PLAYER                  = "Player"; // Marks the player impregnated someone
 const PREGNANCY_AMILY                   = "Amily";
+
+// Misc Pregnancy flags
+const PC_PENDING_PREGGERS               = "PC_Pending_Preggers"; // Unsure what this is for. Used in Amily Herm Quest.
 
 //------------
 // ENCOUNTERS

--- a/js/player.js
+++ b/js/player.js
@@ -1465,8 +1465,8 @@ Player.prototype.changeGems = function(amount) {
     refreshStats();
 }
 
-//PREGNANCY
+//PREGNANCY OLD CODE
 // Initialize player Pregnancy array
-playerPregnancy = new PregnancyStore.Pregnancy(0,0,0,0);
+//playerPregnancy = new PregnancyStore.Pregnancy(0,0,0,0);
 // Add at start to timeAware
-timeAware.push(playerPregnancy);
+//timeAware.push(playerPregnancy);

--- a/js/player.js
+++ b/js/player.js
@@ -1464,3 +1464,9 @@ Player.prototype.changeGems = function(amount) {
     if (player.gems > Number.MAX_VALUE) player.gems = Number.MAX_VALUE;
     refreshStats();
 }
+
+//PREGNANCY
+// Initialize player Pregnancy array
+playerPregnancy = new PregnancyStore.Pregnancy(0,0,0,0);
+// Add at start to timeAware
+timeAware.push(playerPregnancy);

--- a/js/pregnancy.js
+++ b/js/pregnancy.js
@@ -156,14 +156,15 @@ PregnancyStore.Pregnancy.prototype.knockUpForce = function(newPregType, newPregI
 	//	return;
     };
 
-// Time advacement function. Currently only works with normal pregnancy.
+// Time advacement function. Currently only works with normal pregnancy. OLD CODE
+/*
 PregnancyStore.Pregnancy.prototype.advanceTime = function(timeInc) {
 	if (this.pregnancyIncubationFlag >= 1) {
 		// Decrement the incubation flag
 		//outputText("Decrementing Incubation Flag");
 		for (i=0; i < timeInc; i++) {
 			this.pregnancyIncubationFlag--; // Reduce overall timer
-			if (this.pregnancyIncubationFlag < 0) { this.pregnancyIncubationFlag = 0;}
+			if (this.pregnancyIncubationFlag < 0) { this.pregnancyIncubationFlag = 0;}			
 		}
 		// Checking for new Event Array
 		//outputText("Checking Event Array");
@@ -177,6 +178,9 @@ PregnancyStore.Pregnancy.prototype.advanceTime = function(timeInc) {
 	}
 	return;
 };
+*/
+
+
 
 /*
  //this._pregnancyEventValue = [];
@@ -189,10 +193,13 @@ PregnancyStore.Pregnancy.prototype.advanceTime = function(timeInc) {
 */
     // Pregnancy methods
 
+/*
 PregnancyStore.Pregnancy.prototype.type = function(type) {
 		if (this.pregnancyTypeFlag == 0) {return 0;}
 		else { return this.pregnancyTypeFlag }
 	};
+*/
+
 
 /*
     

--- a/js/pregnancy.js
+++ b/js/pregnancy.js
@@ -126,7 +126,8 @@ PregnancyStore.Pregnancy.prototype.knockUp = function(newPregType, newPregIncuba
 {
 	if (this.pregnancyTypeFlag == 0) {
 		this.pregnancyTypeFlag = newPregType;
-		this.pregnancyIncubationFlag = newPregIncubation * 60;}
+		this.pregnancyIncubationFlag = newPregIncubation * 60;
+		this.pregnancyEventCounter = 0;}
 }
 
 // Forces pregnancy regardless of existing pregnancy.
@@ -141,6 +142,7 @@ PregnancyStore.Pregnancy.prototype.knockUpForce = function(newPregType, newPregI
 
     this.pregnancyTypeFlag = newPregType;
     this.pregnancyIncubationFlag = newPregIncubation * 60; // Converts hours into minutes
+	this.pregnancyEventCounter = 0; // Resets event counter.
 	// Debugging text
     //outputText("<br><br>You knocked someone up!");
     //outputText("<br>Pregnancy flag is " + this.pregnancyTypeFlag);

--- a/js/pregnancy.js
+++ b/js/pregnancy.js
@@ -10,7 +10,7 @@ const PREGNANCY_CENTAUR               =   7;
 const PREGNANCY_MARBLE                =   8;
 const PREGNANCY_BUNNY                 =   9;
 const PREGNANCY_ANEMONE               =  10;
-const PREGNANCY_AMILY                 =  11;
+//const PREGNANCY_AMILY                 =  11;
 const PREGNANCY_IZMA                  =  12;
 const PREGNANCY_SPIDER                =  13;
 const PREGNANCY_BASILISK              =  14;
@@ -122,7 +122,15 @@ PregnancyStore.Pregnancy.prototype.eventFill = function(hourArray) {
 	this.pregnancyEventArray = hourArray.map(function(item) { return item * 60; });
 }
 
-PregnancyStore.Pregnancy.prototype.knockUpForce = function (newPregType, newPregIncubation) {
+PregnancyStore.Pregnancy.prototype.knockUp = function(newPregType, newPregIncubation)
+{
+	if (this.pregnancyTypeFlag == 0) {
+		this.pregnancyTypeFlag = newPregType;
+		this.pregnancyIncubationFlag = newPregIncubation * 60;}
+}
+
+// Forces pregnancy regardless of existing pregnancy.
+PregnancyStore.Pregnancy.prototype.knockUpForce = function(newPregType, newPregIncubation) {
     // Passing 0 and 0  to this function now clears out pregnancy.
 	/*
 	if (newPregType == 0 || newPregIncubation == 0) {
@@ -176,13 +184,15 @@ PregnancyStore.Pregnancy.prototype.advanceTime = function(timeInc) {
     
 	//if (pregType < 0 || pregType > MAX_FLAG_VALUE || pregInc < 0 || pregInc > MAX_FLAG_VALUE || buttPregType < 0 || buttPregType > MAX_FLAG_VALUE || buttPregInc < 0 || buttPregInc > MAX_FLAG_VALUE || pregType == buttPregType || pregInc == buttPregInc) {
 	//trace("Error: PregnancyStore created with invalid values for its flags. PregnancyStore(" + pregType + ", " + pregInc + ", " + buttPregType + ", " + buttPregInc + ")");	}
-
+*/
     // Pregnancy methods
-    
-//    this.type = function () { 
-        //if _pregnancyTypeFlag == 0 return 0;
-    //    else return _pregnancyTypeFlag; // & PREG_TYPE_MASK?
-      //  }
+
+PregnancyStore.Pregnancy.prototype.type = function(type) {
+		if (this.pregnancyTypeFlag == 0) {return 0;}
+		else { return this.pregnancyTypeFlag }
+	};
+
+/*
     
 // isPregnant rewrite. Checks to see if Amily is pregnant
     
@@ -204,13 +214,8 @@ PregnancyStore.Pregnancy.prototype.advanceTime = function(timeInc) {
 
 		public function get isButtPregnant():Boolean { return buttType != 0; } //At birth the incubation can be zero so a check vs. type is safer
 */		
-		/* Using this function adds a series of events which happen during the pregnancy. They must be added in descending order (ex. 500, 450, 350, 225, 100, 25)
-		   to work properly. For NPCs who have multiple pregnancy types each type has its own set of events. Events can be used to see how far along the NPC
-		   is in her pregnancy with the event property. They can also be checked using the eventTriggered() function. This checks to see which was the latest event
-		   the player noticed. The eventTriggered() function only triggers once per event per pregnancy. */
 
 /*
-
 
 		//Same as addPregnancyEventSet, but for butts
 		public function addButtPregnancyEventSet(buttPregType:int, ... buttPregStage):void
@@ -222,10 +227,7 @@ PregnancyStore.Pregnancy.prototype.advanceTime = function(timeInc) {
 			_buttPregnancyEventValue.push(pregVector);
 		}
 		
-		public function knockUp(newPregType:int = 0, newPregIncubation:int = 0):void
-		{
-			if (!isPregnant) knockUpForce(newPregType, newPregIncubation);
-		}
+
 		
 		
 	

--- a/js/pregnancyProgression.js
+++ b/js/pregnancyProgression.js
@@ -1,13 +1,170 @@
 /*
- This file contains the detailed code for handling player pregnancy, heat, and other things. pregnancy.js will still count down the pregnancy.
+ This file contains the detailed code for handling player pregnancy, heat, and other things. pregnancy.js will still count down the pregnancy, but this holds everything else. Check time.js for how it is called.
+
  */
 
 var pregnancyProgression = [];
+var statControl = 0; // This prevents huge stat freakouts while pregnant
 
-pregnancyProgression.pregProg = function() {
-return;
-};
+pregnancyProgression.updatePregnancy = function() {
+    var displayedUpdate = false;
+    //outputText("Reached Pregnancy Loop.<br><br>");
+    // Player is pregnant with mice messages and transformations.
+    if (playerPregnancy.pregnancyTypeFlag == PREGNANCY_AMILY) {
+        switch (playerPregnancy.pregnancyEventCounter) {
+            case 1:
+                outputText("<b>You wake up feeling bloated, and your belly is actually looking a little puffy. At the same time, though, you have the oddest cravings... you could really go for some mixed nuts. And maybe a little cheese, too.</b><br><br>");
+                displayedUpdate = true;
+                break;
+            case 2:
+                outputText("<b>Your belly is getting more noticeably distended and squirming around.  You are probably pregnant.</b><br><br>", false);
+                displayedUpdate = true;
+                break;
+            case 3:
+                outputText("<b>There is no question you're pregnant; your belly is already as big as that of any pregnant woman back home. ");
+                if (gameFlags[AMILY_FOLLOWER] == 1) outputText("  Amily smiles at you reassuringly. \"<i>We do have litters, dear, this is normal.</i>\"");
+                outputText("</b><br><br>");
+                if (statControl == 0) {
+                    player.modStats("spe", -1);
+                    player.modStats("lib", 1);
+                    player.modStats("sen", 1);
+                    player.changeLust(2);
+                    statControl++;
+                }
+                displayedUpdate = true;
+                break;
+            case 4:
+                outputText("<b>The sudden impact of a tiny kick from inside your distended womb startles you.  Moments later it happens again, making you gasp.</b><br><br>");
+                displayedUpdate = true;
+                break;
+            case 5:
+                outputText("<b>You feel (and look) hugely pregnant, now, but you feel content. You know the, ah, 'father' of these children loves you, and they will love you in turn.</b><br><br>");
+                displayedUpdate = true;
+                break;
+            case 6:
+                outputText("<b>You jolt from the sensation of squirming inside your swollen stomach. Fortunately, it dies down quickly, but you know for a fact that you felt more than one baby kicking inside you.</b><br><br>");
+                    if (statControl == 1) {
+                        player.modStats("spe", -3);
+                        player.modStats("lib", 1);
+                        player.modStats("sen", 1);
+                        player.changeLust(4);
+                        statControl++;
+                    }
+                displayedUpdate = true;
+                break;
+            case 7:
+                outputText("<b>The children kick and squirm frequently. Your bladder, stomach and lungs all feel very squished. You're glad that they'll be coming out of you soon.</b><br><br>");
+                break;
+            default:
 
-pregnancyProgression.updatePregnancy = function () {
-return;
+            }
+
+        // Fill player's breasts with milk when knocked up by Amily.
+        if (playerPregnancy.pregnancyEventCounter >= 5 && playerPregnancy.pregnancyEventCounter <= 8) {
+            // outputText("<b>Reached Tit Growth Amily Loop</b><br><br>");
+            if (player.biggestTitSize() >= 3 && player.mostBreastsPerRow() > 1 && player.biggestLactation() >= 1 && player.biggestLactation() < 2) {
+                outputText("Your breasts feel swollen with all the extra milk they're accumulating.<br><br>");
+                player.boostLactation(.5);
+            }
+            if (player.biggestTitSize() >= 3 && player.mostBreastsPerRow() > 1 && player.biggestLactation() > 0 && player.biggestLactation() < 1) {
+                outputText("Drops of breastmilk escape your nipples as your body prepares for the coming birth.<br><br>");
+                player.boostLactation(.5);
+            }
+            if (player.biggestTitSize() >= 3 && player.mostBreastsPerRow() > 1 && player.biggestLactation() == 0) {
+                outputText("<b>You realize your breasts feel full, and occasionally lactate</b>.  It must be due to the pregnancy.<br><br>");
+                player.boostLactation(1);
+            }
+            if (player.biggestTitSize() == 2 && player.mostBreastsPerRow() > 1) {
+                outputText("<b>Your breasts have swollen to C-cups,</b> in light of your coming pregnancy.<br><br>");
+                player.growTits(1, 1, false, 3);
+            }
+            if (player.biggestTitSize() == 1 && player.mostBreastsPerRow() > 1) {
+                outputText("<b>Your breasts have grown to B-cups,</b> likely due to the hormonal changes of your pregnancy.<br>");
+                player.growTits(1, 1, false, 3);
+            }
+        }
+
+        // Player giving birth to Amily's babies
+        //Amily failsafes to convert pure Amily babies to mouse babies under certain circumstances.
+
+        if (playerPregnancy.pregnancyIncubationFlag == 0 && playerPregnancy.pregnancyTypeFlag == PREGNANCY_AMILY)
+        {
+            statControl = 0; // Reset stat controller
+            if (gameFlags[AMILY_FOLLOWER] == 2 || gameFlags[AMILY_CORRUPTION_PATH] > 0) playerPregnancy.knockUpForce(PREGNANCY_MOUSE, playerPregnancy.pregnancyIncubationFlag);
+            if (gameFlags[AMILY_VISITING_URTA] == 1 || gameFlags[AMILY_VISITING_URTA] == 2) playerPregnancy.knockUpForce(PREGNANCY_MOUSE, playerPregnancy.pregnancyIncubationFlag);
+            //if (prison.inPrison) player.knockUpForce(PregnancyStore.PREGNANCY_MOUSE, player.pregnancyIncubation);
+        }
+
+        //Give birth to pure Amily's kids
+        if (playerPregnancy.pregnancyIncubationFlag == 0 && playerPregnancy.pregnancyTypeFlag == PREGNANCY_AMILY) {
+            player.boostLactation(.01);
+            outputText("<br>");
+            if (player.vaginas.length == 0) {
+                outputText("You feel a terrible pressure in your groin... then an incredible pain accompanied by the rending of flesh.  <b>You look down and behold a new vagina</b>.  ");
+                player.createVagina();
+                player.genderCheck();
+            }
+
+            AmilyScene.pcBirthsAmilysKidsQuestVersion();
+            player.cuntChange(60, true, true, false);
+            if (player.vaginas[0].vaginalWetness == VAGINA_WETNESS_DRY) player.vaginas[0].vaginalWetness++;
+            player.orgasm();
+            player.modStats("str", -1,"tou", -2, "spe", 3, "lib", 1, "sen", .5);
+            displayedUpdate = true;
+            outputText("<br><br>");
+            playerPregnancy.knockUpForce(0,0); //Clear Pregnancy
+        }
+
+        //Give birth to generic mice and Jojo's / Joy's babies
+        /*
+        if (player.pregnancyIncubation == 1 && (player.pregnancyType == PregnancyStore.PREGNANCY_MOUSE || player.pregnancyType == PregnancyStore.PREGNANCY_JOJO)) {
+            player.boostLactation(.01);
+            outputText("\nYou wake up suddenly to strong pains and pressures in your gut. As your eyes shoot wide open, you look down to see your belly absurdly full and distended. You can feel movement underneath the skin, and watch as it is pushed out in many places, roiling and squirming in disturbing ways. The feelings you get from inside are just as disconcerting. You count not one, but many little things moving around inside you. There are so many, you can't keep track of them.\n\n", false);
+            if (player.vaginas.length == 0) {
+                outputText("You feel a terrible pressure in your groin... then an incredible pain accompanied by the rending of flesh.  <b>You look down and behold a new vagina</b>.  ", false);
+                player.createVagina();
+                player.genderCheck();
+            }
+
+         //Main Text here
+         if (player.pregnancyType == PregnancyStore.PREGNANCY_JOJO && (getGame().monk < 0 || flags[kFLAGS.JOJO_BIMBO_STATE] >= 3) && !prison.inPrison) {
+         if (flags[kFLAGS.JOJO_BIMBO_STATE] >= 3) {
+         kGAMECLASS.joyScene.playerGivesBirthToJoyBabies();
+         return true;
+         }
+         else kGAMECLASS.jojoScene.giveBirthToPureJojoBabies();
+         }
+         else {
+         outputText("Pain shoots through you as they pull open your cervix forcefully. You grip the ground and pant and push as the pains of labor overwhelm you. You feel your hips being forceably widened by the collective mass of the creatures moving down your birth canal. You spread your legs wide, laying your head back with groans and cries of agony as little white figures begin to emerge from between the lips of your abused pussy. Large innocent eyes, even larger ears, cute little muzzles, long slender pink tails all appear as the figures emerge. Each could be no larger than six inches tall, but they seem as active and curious as if they were already developed children. \n\n", false);
+         outputText("Two emerge, then four, eight... you lose track. They swarm your body, scrambling for your chest, and take turns suckling at your nipples. Milk does their bodies good, making them grow rapidly, defining their genders as the girls grow cute little breasts and get broader hips and the boys develop their little mouse cocks and feel their balls swell. Each stops suckling when they reach two feet tall, and once every last one of them has departed your sore, abused cunt and drunk their fill of your milk, they give you a few grateful nuzzles, then run off towards the forest, leaving you alone to recover.\n", false);
+         }
+         player.knockUpForce(); //Clear Pregnancy
+         if (player.averageLactation() > 0 && player.averageLactation() < 5) {
+         outputText("Your [chest] won't seem to stop dribbling milk, lactating more heavily than before.", false);
+         player.boostLactation(.5);
+         }
+         player.cuntChange(60, true,true,false);
+         if (player.vaginas[0].vaginalWetness == VAGINA_WETNESS_DRY) player.vaginas[0].vaginalWetness++;
+         if (player.gender == 1) player.gender = 3;
+         if (player.gender == 0) player.gender = 2;
+         player.orgasm();
+         dynStats("str", -1,"tou", -2, "spe", 3, "lib", 1, "sen", .5);
+         displayedUpdate = true;
+         //Butt increase
+         if (player.buttRating < 14 && rand(2) == 0) {
+         if (player.buttRating < 10) {
+         player.buttRating++;
+         outputText("\n\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.", false);
+         }
+         //Big butts grow slower!
+         else if (player.buttRating < 14 && rand(2) == 0) {
+         player.buttRating++;
+         outputText("\n\nYou notice your " + player.buttDescript() + " feeling larger and plumper after the ordeal.", false);
+         }
+         }
+         outputText("\n", false);
+         }*/
+
+     }
+    doNext(playerMenu);
 };

--- a/js/pregnancyProgression.js
+++ b/js/pregnancyProgression.js
@@ -10,8 +10,8 @@ pregnancyProgression.updatePregnancy = function() {
     var displayedUpdate = false;
     //outputText("Reached Pregnancy Loop.<br><br>");
     // Player is pregnant with mice messages and transformations.
-    if (playerPregnancy.pregnancyTypeFlag == PREGNANCY_AMILY) {
-        switch (playerPregnancy.pregnancyEventCounter) {
+    if (player.pregnancyType == PREGNANCY_AMILY) {
+        switch (player.pregnancyEventNum) {
             case 1:
                 outputText("<b>You wake up feeling bloated, and your belly is actually looking a little puffy. At the same time, though, you have the oddest cravings... you could really go for some mixed nuts. And maybe a little cheese, too.</b><br><br>");
                 displayedUpdate = true;
@@ -60,7 +60,7 @@ pregnancyProgression.updatePregnancy = function() {
             }
 
         // Fill player's breasts with milk when knocked up by Amily.
-        if (playerPregnancy.pregnancyEventCounter >= 5 && playerPregnancy.pregnancyEventCounter <= 8) {
+        if (player.pregnancyEventNum >= 5 && player.pregnancyEventNum <= 8) {
             // outputText("<b>Reached Tit Growth Amily Loop</b><br><br>");
             if (player.biggestTitSize() >= 3 && player.mostBreastsPerRow() > 1 && player.biggestLactation() >= 1 && player.biggestLactation() < 2) {
                 outputText("Your breasts feel swollen with all the extra milk they're accumulating.<br><br>");
@@ -87,16 +87,16 @@ pregnancyProgression.updatePregnancy = function() {
         // Player giving birth to Amily's babies
         //Amily failsafes to convert pure Amily babies to mouse babies under certain circumstances.
 
-        if (playerPregnancy.pregnancyIncubationFlag == 0 && playerPregnancy.pregnancyTypeFlag == PREGNANCY_AMILY)
+        if (player.pregnancyIncubation == 0 && player.pregnancyType == PREGNANCY_AMILY)
         {
             statControl = 0; // Reset stat controller
-            if (gameFlags[AMILY_FOLLOWER] == 2 || gameFlags[AMILY_CORRUPTION_PATH] > 0) playerPregnancy.knockUpForce(PREGNANCY_MOUSE, playerPregnancy.pregnancyIncubationFlag);
-            if (gameFlags[AMILY_VISITING_URTA] == 1 || gameFlags[AMILY_VISITING_URTA] == 2) playerPregnancy.knockUpForce(PREGNANCY_MOUSE, playerPregnancy.pregnancyIncubationFlag);
+            if (gameFlags[AMILY_FOLLOWER] == 2 || gameFlags[AMILY_CORRUPTION_PATH] > 0) player.knockUpForce(PREGNANCY_MOUSE, player.pregnancyIncubationFlag);
+            if (gameFlags[AMILY_VISITING_URTA] == 1 || gameFlags[AMILY_VISITING_URTA] == 2) player.knockUpForce(PREGNANCY_MOUSE, player.pregnancyIncubationFlag);
             //if (prison.inPrison) player.knockUpForce(PregnancyStore.PREGNANCY_MOUSE, player.pregnancyIncubation);
         }
 
         //Give birth to pure Amily's kids
-        if (playerPregnancy.pregnancyIncubationFlag == 0 && playerPregnancy.pregnancyTypeFlag == PREGNANCY_AMILY) {
+        if (player.pregnancyIncubation == 0 && player.pregnancyType == PREGNANCY_AMILY) {
             player.boostLactation(.01);
             outputText("<br>");
             if (player.vaginas.length == 0) {
@@ -112,7 +112,7 @@ pregnancyProgression.updatePregnancy = function() {
             player.modStats("str", -1,"tou", -2, "spe", 3, "lib", 1, "sen", .5);
             displayedUpdate = true;
             outputText("<br><br>");
-            playerPregnancy.knockUpForce(0,0); //Clear Pregnancy
+            player.knockUpForce(0,0); //Clear Pregnancy
         }
 
         //Give birth to generic mice and Jojo's / Joy's babies

--- a/js/pregnancyProgression.js
+++ b/js/pregnancyProgression.js
@@ -1,19 +1,13 @@
 /*
- This file contains the detailed code for handling player pregnancy, heat, and other things. pregnancy.js will still count down the pregnancy. It basically runs of a huge advanceTime function, at least for now.
+ This file contains the detailed code for handling player pregnancy, heat, and other things. pregnancy.js will still count down the pregnancy.
  */
 
-pregnancyProgression = [];
+var pregnancyProgression = [];
 
 pregnancyProgression.pregProg = function() {
 return;
 };
 
-pregnancyProgresssion.pregProg.prototype.advanceTime = new function() {
-        outputText("Checks for player strangeness for pregnancy.");
-
-        
-
- };
-
-timeAware.push(pregnancyProgression.pregProg);
-
+pregnancyProgression.updatePregnancy = function () {
+return;
+};

--- a/js/pregnancyProgression.js
+++ b/js/pregnancyProgression.js
@@ -1,0 +1,19 @@
+/*
+ This file contains the detailed code for handling player pregnancy, heat, and other things. pregnancy.js will still count down the pregnancy. It basically runs of a huge advanceTime function, at least for now.
+ */
+
+pregnancyProgression = [];
+
+pregnancyProgression.pregProg = function() {
+return;
+};
+
+pregnancyProgresssion.pregProg.prototype.advanceTime = new function() {
+        outputText("Checks for player strangeness for pregnancy.");
+
+        
+
+ };
+
+timeAware.push(pregnancyProgression.pregProg);
+

--- a/js/scenes/camp.js
+++ b/js/scenes/camp.js
@@ -56,12 +56,15 @@ Camp.doCamp = function () {
     //Inventory.takeItem(Items.Consumables.IncubiDraftPurified);
     // gameFlags[AMILY_HERM_QUEST] = 2;
     //gameFlags[AMILY_AFFECTION] = 50;
-
-
+    //player.HP = 100;
+    outputText(player.gender + "<br>");
+    outputText("AmilyMet = " + gameFlags[AMILY_MET] + "<br>");
+    outputText("Player pregnancy counter is " + playerPregnancy.pregnancyIncubationFlag + "<br>");
+    outputText("Player knockedup by " + playerPregnancy.pregnancyTypeFlag);
     //Display available options
 	menu();
 
-  	addButton(0, "Explore", Areas.GenericExploration.exploreMenu, null, null, null, "Explore to find new regions and visit any discovered regions.");
+    addButton(0, "Explore", Areas.GenericExploration.exploreMenu, null, null, null, "Explore to find new regions and visit any discovered regions.");
     addButton(1, "Places", Places.placesMenu, null, null, null, "Visit any places you have discovered so far.");
     //addButton(5, "Camp Actions", Camp.campActionsMenu, null, null, null, "Interact with the camp surroundings.");
     if (Camp.followersCount() > 0) addButton(2, "Followers", Camp.campFollowersMenu, null, null, null, "Check up on any followers or companions who are joining you in or around your camp. You'll probably just end up sleeping with them.");
@@ -74,6 +77,8 @@ Camp.doCamp = function () {
     };    
     addButton(13, "Inventory", Inventory.inventoryMenu, null, null, null, "The inventory allows you to use an item. Be careful as this leaves you open to a counterattack when in combat.");
     //addButton(14, "Codex", Codex.readCodex);
+
+
 }
 
 

--- a/js/scenes/camp.js
+++ b/js/scenes/camp.js
@@ -25,7 +25,7 @@ Camp.doCamp = function () {
 	//Display texts
 	clearOutput();
     // Display Pregnancy related events
-    pregnancyProgression.updatePregnancy();
+    //pregnancyProgression.updatePregnancy();
 	/*if (isabellaFollower()) {
 		outputText("Your campsite got a lot more comfortable once Isabella moved in.  Carpets cover up much of the barren ground, simple awnings tied to the rocks provide shade, and hand-made wooden furniture provides comfortable places to sit and sleep.  ", false);
 	}
@@ -61,9 +61,17 @@ Camp.doCamp = function () {
     //player.HP = 100;
     //outputText(player.gender + "<br>");
     //outputText("AmilyMet = " + gameFlags[AMILY_MET] + "<br>");
-    //outputText("Player pregnancy counter is " + playerPregnancy.pregnancyIncubationFlag + "<br>");
-    //outputText("Player knockedup by " + playerPregnancy.pregnancyTypeFlag + "<br>");
-    //outputText("Player pregnancy event counter is " + playerPregnancy.pregnancyEventCounter);
+    //if (!player.isPregnant()) { player.knockUpForce(PREGNANCY_AMILY, 100); }
+    outputText("Player pregnancy counter is " + player.pregnancyIncubation + "<br>");
+    outputText("Player knockedup by " + player.pregnancyType + "<br>");
+
+    //if (!amily.isPregnant()) amily.knockUpForce(PREGNANCY_PLAYER, INCUBATION_MOUSE);
+    outputText("Amily pregnancy counter is " + amily.pregnancyIncubation + "<br>");
+    outputText("Player knockedup by " + amily.pregnancyType + "<br>");
+    outputText("Player pregnancy event counter is " + amily.pregnancyEventNum + "<br><br>");
+
+
+
     //Display available options
 	menu();
 

--- a/js/scenes/camp.js
+++ b/js/scenes/camp.js
@@ -21,9 +21,11 @@ Camp.doCamp = function () {
     else {
         hideMenuButton("buttonLevel");
         }
-	playerMenu = Camp.doCamp;
+    playerMenu = Camp.doCamp;
 	//Display texts
 	clearOutput();
+    // Display Pregnancy related events
+    pregnancyProgression.updatePregnancy();
 	/*if (isabellaFollower()) {
 		outputText("Your campsite got a lot more comfortable once Isabella moved in.  Carpets cover up much of the barren ground, simple awnings tied to the rocks provide shade, and hand-made wooden furniture provides comfortable places to sit and sleep.  ", false);
 	}
@@ -57,10 +59,11 @@ Camp.doCamp = function () {
     // gameFlags[AMILY_HERM_QUEST] = 2;
     //gameFlags[AMILY_AFFECTION] = 50;
     //player.HP = 100;
-    outputText(player.gender + "<br>");
-    outputText("AmilyMet = " + gameFlags[AMILY_MET] + "<br>");
-    outputText("Player pregnancy counter is " + playerPregnancy.pregnancyIncubationFlag + "<br>");
-    outputText("Player knockedup by " + playerPregnancy.pregnancyTypeFlag);
+    //outputText(player.gender + "<br>");
+    //outputText("AmilyMet = " + gameFlags[AMILY_MET] + "<br>");
+    //outputText("Player pregnancy counter is " + playerPregnancy.pregnancyIncubationFlag + "<br>");
+    //outputText("Player knockedup by " + playerPregnancy.pregnancyTypeFlag + "<br>");
+    //outputText("Player pregnancy event counter is " + playerPregnancy.pregnancyEventCounter);
     //Display available options
 	menu();
 
@@ -128,10 +131,10 @@ Camp.doSleep = function() {
     //For now
     clearOutput();
     outputText("You lie down and sleep for eight hours.");
-    Time.advanceHours(8);
     player.changeHP(15 * 8, true);
     player.changeLust(player.lib * 0.04 * 8, false);
     doNext(Camp.doCamp);
+    Time.advanceHours(8);
 };
 
 //UTILS

--- a/js/scenes/combat.js
+++ b/js/scenes/combat.js
@@ -15,6 +15,8 @@ battleMenu = function() {
 	outputText("<br>Lust: " + monster.lust + " / " + monster.maxLust());
 	outputText("<br>Fatigue: " + monster.fatigue + " / " + monster.maxFatigue());
 	refreshStats();
+    //DEBUGGING code to check wins
+    //player.HP = 100;
 	hideUpDown();
 	menu();
 	addButton(0, "Attack", attack);

--- a/js/scenes/combatTeases.js
+++ b/js/scenes/combatTeases.js
@@ -1365,7 +1365,7 @@ function teaseMain(justText) {
         //else if (monster is Doppleganger && monster.findStatusEffect(StatusEffects.Stunned) < 0) (monster as Doppleganger).mirrorTease(damage, true);
         /*else */if (!justText) monster.teased(damage);
 
-        if (flags[PC_FETISH] >= 1/* && !urtaQuest.isUrta()*/) {
+        if (gameFlags[PC_FETISH] >= 1/* && !urtaQuest.isUrta()*/) {
             if (player.lust < 75)
                 outputText("<br>Flaunting your body in such a way gets you a little hot and bothered. ");
             else

--- a/js/scenes/npcs/amily.js
+++ b/js/scenes/npcs/amily.js
@@ -1,5 +1,5 @@
 var AmilyScene = [];
-
+var amily;
 /*
  * Amily created by aimozg on 02.01.14.
  * Converted to JS by Matraia
@@ -97,11 +97,36 @@ function Amily() {
     //checkMonster();
     this.victory = AmilyScene.rapeCorruptAmily1;
     this.defeat = cleanupAfterCombat;
+    //Pregnancy
+    this.pregnancyType = 0;
+    this.pregnancyIncubation = 0;
+    this.pregnancyEventArr = [];
+    this.pregnancyEventNum = 0;
+    this.buttPregnancyType = 0;
+    this.buttPregnancyIncubation = 0;
+    this.buttPregnancyEventArr = [];
+    this.buttPregnancyEventNum = 0;
 }
+
 Amily.prototype = new Creature();
 Amily.prototype.constructor = Amily;
+amily = new Amily();
 
 var sexForced = false; // Used to get around a nasty bug.
+
+
+//Okay, let's get this pregnancy system right...
+
+// Add a pregnancy array OLD CODE
+//AmilyScene.pregnancy = new PregnancyStore.Pregnancy(gameFlags[AMILY_PREGNANCY_TYPE], gameFlags[AMILY_INCUBATION], gameFlags[AMILY_BUTT_PREGNANCY_TYPE], gameFlags[AMILY_OVIPOSITED_COUNTDOWN]);
+
+// Add a pregnancy event array NEW CODE
+amily.eventFill(INCUBATION_AMILY_EVENT);
+
+// Make the pregnancy for the character time-aware OLD CODE
+//timeAware.push(AmilyScene.pregnancy);
+
+
 
 
 // Used for later checks when Amily is a follower. - COMPLETE
@@ -206,9 +231,9 @@ AmilyScene.start = function () {
 
 
     //If Amily is ready to give birth, do this
-    if (AmilyScene.amilyPregnancy.isPregnant() == true && AmilyScene.amilyPregnancy.pregnancyIncubationFlag == 0) {
+    if (amily.isPregnant() == true && amily.pregnancyIncubation == 0) {
         AmilyScene.amilyGivesBirth();
-        AmilyScene.amilyPregnancy.knockUpForce(0, 0); //Clear Pregnancy
+        amily.knockUpForce(0, 0); //Clear Pregnancy
         return;
     }
 
@@ -520,7 +545,7 @@ AmilyScene.start = function () {
         clearOutput();
         // Amily does NOT like seeing the player change gender
         outputText("Curious on how Amily is holding up, you head back into the ruined village. This time you don't bother trying to hide your presence, hoping to attract Amily's attention quicker. After all, she did say that the place is basically empty of anyone except her, and you can otherwise handle a measly Imp or Goblin.<br><br>");
-        switch (AmilyScene.amilyPregnancy.pregnancyEventCounter) {
+        switch (amily.pregnancyEventNum) {
             case 1:
             case 2:
             case 3:
@@ -882,11 +907,11 @@ AmilyScene.start = function () {
 
         outputText("You point out that it would be for the best for her plans; this way, the two of you will be able to bear litters simultaneously, so she can have children even faster and in greater numbers than before. Giving her a winning smile, you clasp hold of her hands gently and ask if she'll please consider doing it; for you?<br><br>");
 
-        outputText("Amily looks crestfallen, then finally nods her head, slowly. \"<i>I... I'm not really sure about this, but... if it's for you, " + player.name + ", then... I'll do it.</i>\" She takes the vial, staring at it apprehensively, then pops the cork and swallows it down quickly in a single gulp. She shudders - first in disgust at what she actually drank, then with pleasure. Moaning ecstatically, she " + (AmilyScene.amilyPregnancy.pregnancyEventCounter >= 6 ? "lifts her shirt" : "pulls off her pants") + " to give you a full view as her clitoris swells, longer and thicker; finally, skin peels back at the tip to reveal what is unmistakably the glans of a penis, complete with a cum-gouting slit as she experiences her first male orgasm.<br><br>");
+        outputText("Amily looks crestfallen, then finally nods her head, slowly. \"<i>I... I'm not really sure about this, but... if it's for you, " + player.name + ", then... I'll do it.</i>\" She takes the vial, staring at it apprehensively, then pops the cork and swallows it down quickly in a single gulp. She shudders - first in disgust at what she actually drank, then with pleasure. Moaning ecstatically, she " + (amily.pregnancyEventNum >= 6 ? "lifts her shirt" : "pulls off her pants") + " to give you a full view as her clitoris swells, longer and thicker; finally, skin peels back at the tip to reveal what is unmistakably the glans of a penis, complete with a cum-gouting slit as she experiences her first male orgasm.<br><br>");
 
         outputText("Amily is now a hermaphrodite. Her human-like penis is four inches long and one inch thick.<br><br>");
 
-        outputText("Catching her breath, she " + (AmilyScene.amilyPregnancy.pregnancyEventCounter >= 6 ? "tries to get a look at her new member over her bulging belly. When that fails she runs her hand over it, touching it carefully while maintaining an unreadable expression. Then she stares at you and says, " : "stares at her new appendage with an unreadable expression, then she stares at you.") + " \"<i>Well, now I've got a penis... so that means you're coming with me to let me try it out!</i>\"<br><br>");
+        outputText("Catching her breath, she " + (amily.pregnancyEventNum >= 6 ? "tries to get a look at her new member over her bulging belly. When that fails she runs her hand over it, touching it carefully while maintaining an unreadable expression. Then she stares at you and says, " : "stares at her new appendage with an unreadable expression, then she stares at you.") + " \"<i>Well, now I've got a penis... so that means you're coming with me to let me try it out!</i>\"<br><br>");
 
 
         outputText("You agree  and allow her to begin leading you to the \"<i>bedroom</i>\".");
@@ -1260,7 +1285,7 @@ AmilyScene.start = function () {
 
         //[Low Affection]
         if (gameFlags[AMILY_AFFECTION] < 15) {
-            switch (AmilyScene.amilyPregnancy.pregnancyEventCounter) {
+            switch (amily.pregnancyEventNum) {
                 case 1:
                 case 2:
                 case 3:
@@ -1764,7 +1789,7 @@ AmilyScene.start = function () {
         clearOutput();
 
         outputText("You tell Amily that you came here because you wanted to talk with her.  If she feels like having sex when you are done, though, you would be happy to oblige.<br><br>");
-        switch (AmilyScene.amilyPregnancy.pregnancyEventCounter) {
+        switch (amily.pregnancyEventNum) {
             case 1:
             case 2:
             case 3:
@@ -1891,18 +1916,18 @@ AmilyScene.amilySexHappens = function () {
             outputText("Amily leads you to her nest as quickly as ever, but things are a little different this time. You can tell Amily has what can only be described as a 'spring in her step'. She moves just a little bit quicker, she seems more enthusiastic about the prospect - her tail even waves slowly from side to side, a bit of body language you haven't seen from her before. And you're certain there's a bit of a seductive wiggle to her hips - which you definitely haven't seen from her before.");
 
             //(If Amily is Slightly Pregnant:
-            if (AmilyScene.amilyPregnancy.pregnancyEventCounter >= 1 && AmilyScene.amilyPregnancy.pregnancyEventCounter <= 5) outputText("  However, she does sometimes touch the swell signifying the litter growing inside her, and when she does her attitude becomes uncertain and nervous.");
+            if (amily.pregnancyEventNum >= 1 && amily.pregnancyEventNum <= 5) outputText("  However, she does sometimes touch the swell signifying the litter growing inside her, and when she does her attitude becomes uncertain and nervous.");
 
             outputText("<br><br>");
 
             outputText("Once you are inside, Amily gently tries to push you onto the bedding where you will be mating. Once you are seated, she smiles at you with a teasing expression and begins to slowly strip herself off, clearly trying to make the act seem as erotic as possible.");
 
-            if (AmilyScene.amilyPregnancy.pregnancyEventCounter >= 6) outputText("  However, her confidence visibly slips when she has to fully bare the bulging belly that marks her pregnant state, but she musters the confidence and starts to show it off for you as well.");
+            if (amily.pregnancyEventNum >= 6) outputText("  However, her confidence visibly slips when she has to fully bare the bulging belly that marks her pregnant state, but she musters the confidence and starts to show it off for you as well.");
             addButton(0, "Step In", AmilyScene.amilySexStepIn, null, null, null, "Why not let me do that for you?");
             addButton(1, "Watch Show", AmilyScene.amilySexEnjoyShow, null, null, null, "She's getting better at this...");
             //
         } else { // High Affection
-            if (AmilyScene.amilyPregnancy.pregnancyEventCounter >= 6) AmilyScene.fuckAmilyPreg();
+            if (amily.pregnancyEventNum >= 6) AmilyScene.fuckAmilyPreg();
             //else
             AmilyScene.amilyHighAffectionSex();
         }
@@ -1923,7 +1948,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
     if (gameFlags[AMILY_CONFESSED_LESBIAN] > 0 && player.gender == 2) {
         if (gameFlags[AMILY_WANG_LENGTH] > 0) {
          //If not pregnant, always get fucked!
-            if (!AmilyScene.amilyPregnancy.isPregnant()) AmilyScene.amilyHermOnFemalePC();
+            if (!amily.isPregnant()) AmilyScene.amilyHermOnFemalePC();
          //else 50/50
             else {
             if (rand(2) == 0) AmilyScene.girlyGirlMouseSex();
@@ -1941,9 +1966,9 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
          //Amily is herm too!
         if (gameFlags[AMILY_WANG_LENGTH] > 0) {
          //If Amily is not pregnant
-            if (!AmilyScene.amilyPregnancy.isPregnant()) {
+            if (!amily.isPregnant()) {
          //If PC is also not pregnant, 50/50 odds
-                if (!player.pregnancy.isPregnant()) {
+                if (!player.isPregnant()) {
          //Herm Amily knocks up PC
                     if (rand(2) == 0) AmilyScene.amilyHermOnFemalePC();
          //PC uses dick on amily
@@ -1962,7 +1987,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
          //Amily is preg
             else {
                 //Pc is not
-                if (!player.pregnancy.isPregnant()) AmilyScene.amilyHermOnFemalePC();
+                if (!player.isPregnant()) AmilyScene.amilyHermOnFemalePC();
                 //PC is preg too!
                 else {
                     //Herm Amily knocks up PC
@@ -1978,7 +2003,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
          //Amily still girl!
         else {
          //Not pregnant? KNOCK THAT SHIT UP
-            if (!player.pregnancy.isPregnant()) AmilyScene.sexWithAmily();
+            if (!player.isPregnant()) AmilyScene.sexWithAmily();
          //Pregnant?  Random tribbing!
             else {
          //Lesbogrind
@@ -2010,7 +2035,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
         outputText("You tell Amily that you came here because you wanted to have sex with her.<br><br>");
 
 
-        switch (AmilyScene.amilyPregnancy.pregnancyEventCounter) {
+        switch (amily.pregnancyEventNum) {
             case 1:
             case 2:
             case 3:
@@ -2233,7 +2258,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
         clearOutput();
 
         outputText("Surprised, curious and aroused in equal measures, you decide to sit back and watch the show. Amily seems very happy to perform for you, and does her best to make it as intriguing as possible.");
-        if (AmilyScene.amilyPregnancy.pregnancyEventCounter >= 6) outputText("  Even though she was clearly a little nervous about her gravid state in the beginning, as she continues, she grows in confidence to the point it seems she has almost forgotten about it.");
+        if (amily.pregnancyEventNum >= 6) outputText("  Even though she was clearly a little nervous about her gravid state in the beginning, as she continues, she grows in confidence to the point it seems she has almost forgotten about it.");
         outputText("<br><br>");
         AmilyScene.amilySexMidPartII();
     };
@@ -2342,12 +2367,12 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
         var x = player.cockThatFits(61);
         outputText("Amily really didn't waste any time getting to her hidden bedroom, sprinting as fast as she could with you in tow.");
 
-        if (AmilyScene.amilyPregnancy.isPregnant) outputText("  Even in a slightly pregnant state, she goes surprisingly fast, though she's also rather cautious of her small bump.");
+        if (amily.isPregnant()) outputText("  Even in a slightly pregnant state, she goes surprisingly fast, though she's also rather cautious of her small bump.");
         outputText("<br><br>");
 
         outputText("Once inside, the two of you get to work undoing each others clothes, tossing the garments across the room with little care for them. Amily bites her lower lip as she examines your naked form again, before practically jumping you. She wraps her small hands around your stiff " + Appearance.cockNoun(player.cocks[x].cockType) + " in an almost painful fashion, rubbing and teasing it, and presses her mouth against yours, her tongue exploring every inch of your mouth that it can reach, and you quickly respond by doing the same favor for Amily.");
 
-        if (AmilyScene.amilyPregnancy.isPregnant) outputText("  Really it seems the only thing between you two now is Amily's small stomach bulge.");
+        if (amily.isPregnant()) outputText("  Really it seems the only thing between you two now is Amily's small stomach bulge.");
 
         //(If Amily is herm:
         if (gameFlags[AMILY_WANG_LENGTH] > 0) outputText("  You can feel her erection, hot and solid, pressed between your two bodies.");
@@ -2361,25 +2386,25 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
         else outputText("licking and kissing her human-like cock");
 
         outputText(" to stimulate her further. In response, Amily moans loudly and spreads her legs further apart, an invitation to continue. You happily oblige your lover, burying two fingers into her wet cunt while you move to other parts of her body.");
-        if (AmilyScene.amilyPregnancy.isPregnant) outputText("  As you move your head across her beautiful form, you stop at her growing baby bump and give it a small kiss.");
+        if (amily.isPregnant()) outputText("  As you move your head across her beautiful form, you stop at her growing baby bump and give it a small kiss.");
         outputText("  Your head hovers at her breasts");
-        if (AmilyScene.amilyPregnancy.isPregnant) outputText(", which seem to have grown from the pregnancy,");
+        if (amily.isPregnant()) outputText(", which seem to have grown from the pregnancy,");
 
         outputText(" and get to work licking and suckling her nipples, rubbing the sensitive mounds.");
-        if (AmilyScene.amilyPregnancy.isPregnant) outputText("  When you get a dribble of milk in your mouth it surprises you, but you certainly don't stop.  \"<i>Hah...You're going to have to teach the children how that's done,</i>\" Amily says, in between fevered breaths.");
+        if (amily.isPregnant()) outputText("  When you get a dribble of milk in your mouth it surprises you, but you certainly don't stop.  \"<i>Hah...You're going to have to teach the children how that's done,</i>\" Amily says, in between fevered breaths.");
         outputText("<br><br>");
 
         outputText("By the time you start teasing her neck and collarbone, Amily's hands are clinging onto your back and she's impatiently grinding against your raging erection.  \"<i>Please don't tease me anymore,</i>\" Amily whispers into your ear, making you almost feel a little bad for teasing your love in such a way.<br><br>");
 
         outputText("As an apology you quickly push your " + player.cockDescript(x) + " past her dampened nether-lips, and set to work thrusting in and out of your mousegirl lover.");
 
-        if (AmilyScene.amilyPregnancy.isPregnant) outputText("  You are of course mindful of her baby bump, not going too fast and making sure you're in a position that's comfortable for the two of you, not wanting to harm your future offspring with the lovely mouse maiden.");
+        if (amily.isPregnant()) outputText("  You are of course mindful of her baby bump, not going too fast and making sure you're in a position that's comfortable for the two of you, not wanting to harm your future offspring with the lovely mouse maiden.");
 
         outputText("  It's not too long before you're going at a regular pace, stuffing Amily's fuckhole with your familiar manhood.<br><br>");
 
         outputText("Amily moans from the pleasure and raises her hips up to meet your thrusts, desperate for more of your loving.  She whispers a few dirty things to you between shallow breaths, \"<i>");
 
-        if (!AmilyScene.amilyPregnancy.isPregnant) outputText("Fill me up with everything you have... I want to be a mother for your children, just as much as I want to be a mother of my own people,");
+        if (!amily.isPregnant()) outputText("Fill me up with everything you have... I want to be a mother for your children, just as much as I want to be a mother of my own people,");
         else outputText("No need to hold back, pump as much cum into me as you can,");
 
         outputText("</i>\" she whispers in a sultry tone, and her words are enough to send you over the edge. You grunt loudly, feeling as if your cock is about to explode from the exertion, blasting Amily so full of your cum that it starts to ooze out. Amily gives a cute little cry, and her vaginal walls clamp down on your sensitive member with enough force to make you wince as girlcum sprays out onto your thighs");
@@ -2388,62 +2413,19 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
 
         outputText("<br><br>");
 
-        if (!AmilyScene.amilyPregnancy.isPregnant) outputText("\"<i>If that didn't knock me up... I don't care as much as you'd think. It was magnificent either way,");
+        if (!amily.isPregnant()) outputText("\"<i>If that didn't knock me up... I don't care as much as you'd think. It was magnificent either way,");
         else outputText("\"<i>Hmm...My kids are pretty lucky that their father is such a virile specimen,");
 
         outputText("</i>\" Amily says as she catches her breath, reaching up to ruffle your hair. You give her a bashful smile, glad to see you've made her so happy.<br><br>");
 
         outputText("The two of you lie together for some time, and it's with great regret that you tell her that you need to check in on your own camp. Amily seems disappointed, not wanting you to leave, but understands why you need to go. \"<i>");
 
-        if (!AmilyScene.amilyPregnancy.isPregnant) outputText("Okay... Well, I'm sure you'll be back. I will need your help again if this doesn't set,");
+        if (!amily.isPregnant()) outputText("Okay... Well, I'm sure you'll be back. I will need your help again if this doesn't set,");
 
         else outputText("Okay dear...But you better come back some time. You don't want your children to have abandonment issues, do you?");
 
         outputText("</i>\" Amily says while rubbing her stomach. You smile at her and nod, promising you'll come back, before setting off for your own camp.");
-        /*OLD
-         outputText("Amily really didn't waste any time getting to her hidden bedroom, sprinting as fast as she could with you in tow.");
-         if (gameFlags[AMILY_INCUBATION] > 0) outputText("  Even in a slightly pregnant state she goes surprisingly fast, though she's also rather cautious of her small bump.");
-         outputText("<br><br>");
-
-         outputText("Once inside, the two of you get to work undoing each others clothes, tossing the garments across the room with little care for them. Amily bites her lower lip as she examines your naked form again, before practically jumping you. She wraps her small hands around your stiff " + player.cockDescript(0) + " in an almost painful fashion, rubbing and teasing it, and presses her mouth against yours, her tongue exploring every inch of your mouth that it can reach, and you quickly respond by doing the same favor for Amily.");
-         if (gameFlags[AMILY_INCUBATION] > 0) outputText("  Really it seems the only thing in-between you two now is Amily's small stomach bulge.");
-         outputText("<br><br>");
-
-         outputText("Not releasing her grip on your raging erection, or breaking the passionate kiss for even a single second, she moves back toward the bed and takes you with her. You're quite surprised that the quiet mousegirl has come out of her shell and is being so forward. Is this the effect you have on her?<br><br>");
-
-         outputText("Finally putting some distance between the two of you, Amily flops back onto the bed and places her hands behind her head, presenting her beautiful body to you. Finding the sight irresistible, you move your head between her legs and start licking at her moist vag, pushing your tongue or your fingers in every once in a while, and sucking on her sensitive clit to stimulate her further. In response, Amily moans loudly and spreads her legs further apart, an invitation to continue. You happily oblige your lover, burying two fingers into her wet cunt while you move to other parts of her body.");
-         if (flags[kFLAGS.AMILY_INCUBATION] > 0) outputText("  As you move your head across her beautiful form, you stop at her growing baby bump and give it a small kiss.");
-         outputText("  Your head hovers at her breasts ");
-         if (flags[kFLAGS.AMILY_INCUBATION] > 0) outputText("which seem to have grown from the pregnancy ");
-         outputText("and get to work licking and suckling her nipples, and rubbing the sensitive mounds.");
-         if (flags[kFLAGS.AMILY_INCUBATION] > 0) outputText("  When you get a dribble of milk in your mouth it surprises you, but you certainly don't stop \"<i>Hah... You're going to have to teach the children how that's done,</i>\" Amily says in between fevered breaths.");
-         outputText("<br><br>");
-
-         outputText("By the time you start teasing her neck and collarbone, Amily's hands are clinging onto your back and she's impatiently grinding against your raging erection. \"<i>Please don't tease me anymore...</i>\" Amily whispers into your ear, making you almost feel a little bad for teasing your love in such a way.<br><br>");
-
-         outputText("As an apology you quickly push your " + player.cockDescript(0) + " past her dampened nether-lips, and set to work thrusting in and out of your mousegirl lover.");
-         if (flags[kFLAGS.AMILY_INCUBATION] > 0) outputText("  You are of course mindful of her baby bump, not going too fast and making sure you're in a position that's comfortable for the two of you.  You don't want to harm your future offspring with the lovely mouse maiden.");
-         outputText("  It's not too long before you're going at a regular pace, stuffing Amily's fuckhole with your familiar manhood.<br><br>");
-
-         outputText("Amily moans from the pleasure and raises her hips up to meet your thrusts, desperate for more of your loving, whispering a few dirty things to you between shallow breaths \"<i>");
-         //not preggo
-         if (flags[kFLAGS.AMILY_INCUBATION] == 0) outputText("Fill me up with everything you have...I want to be a mother for your children, just as much as I want to be a mother of my own people...");
-         else outputText("No need to hold back, pump as much cum into me as you can...");
-         outputText("</i>\" she whispers in a sultry tone, and her words are enough to send you over the edge. You grunt loudly, feeling as if your cock is about to explode from the exertion, blasting Amily so full of your cum that it starts to ooze out. Amily gives a cute little cry, and her vaginal walls clamp down on your sensitive member with enough force to make you wince, as girlcum sprays out onto your thighs.<br><br>");
-
-         //no preggo
-         if (flags[kFLAGS.AMILY_INCUBATION] == 0) outputText("\"<i>If that didn't knock me up...I don't care as much as you'd think. It was magnificent either way,");
-         else outputText("\"<i>Hmm...My kids are pretty lucky that their father is such a virile specimen,");
-         outputText("</i>\" Amily says as she catches her breath, reaching up to ruffle your hair. You give her a bashful smile, glad to see you've made her so happy.<br><br>");
-
-         outputText("The two of you lie together for some time, and it's with great regret that you tell her that you need to check in on your own camp. Amily seems dissapointed, not wanting you to leave, but understands why you need to go. \"<i>");
-         //no pregg
-         if (flags[kFLAGS.AMILY_INCUBATION] == 0) outputText("Okay...Well, I'm sure you'll be back. I will need your help again if this doesn't set,");
-         else outputText("Okay dear... but you'd better come back some time. You don't want your children to have abandonment issues, do you?");
-         outputText("</i>\" Amily says, rubbing her stomach. You smile at her and nod, promising you'll come back, before setting off for your own camp.");
-         */
-        //boost affection
-
+       
 
         gameFlags[AMILY_AFFECTION] += 2 + rand(4);
         gameFlags[AMILY_FUCK_COUNTER]++;
@@ -2623,8 +2605,8 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
 
         //(If player is preg
 
-        if (playerPregnancy.isPregnant()) {
-            if (playerPregnancy.pregnancyTypeFlag == "Amily")
+        if (player.isPregnant()) {
+            if (player.pregnancyType == PREGNANCY_AMILY)
          outputText("\"<i>Boy, this is weird.  I'm a woman and I'm going to be a dad.");
          else outputText("\"<i>After you give birth to this baby come and see me when you're ready for mine.  This is really weird, I'm a woman and I can't wait to be a dad.");
          }
@@ -2632,8 +2614,8 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
          else {
          outputText("\"<i>Let's see if you'll be a mommy from this load... If not, well, I guess we'll have to try again.");
          //PREGGO CHECK HERE
-         playerPregnancy.knockUp(PREGNANCY_AMILY, INCUBATION_MOUSE);
-         playerPregnancy.eventFill(INCUBATION_MOUSE_EVENT);
+         player.knockUp(PREGNANCY_AMILY, INCUBATION_MOUSE);
+         player.eventFill(INCUBATION_MOUSE_EVENT);
          }
 
         outputText("</i>\"  Chuckling softly, you lay there and embrace your lover for a time and then, reluctantly, you get dressed and leave.");
@@ -2789,8 +2771,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
     // Amily Pregnancy code and birthing scenes
     //---------
 
-// Pregnancy array for Amily - COMPLETE
-    AmilyScene.amilyPregnancy = new PregnancyStore.Pregnancy(gameFlags[AMILY_PREGNANCY_TYPE], gameFlags[AMILY_INCUBATION], gameFlags[AMILY_BUTT_PREGNANCY_TYPE], gameFlags[AMILY_OVIPOSITED_COUNTDOWN]);
+
 
 
 // COMPLETE
@@ -2801,7 +2782,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
             if (gameFlags[AMILY_ALLOWS_FERTILITY] == 0) return;
         }
         //Cant repreg if already preg!
-        if (AmilyScene.amilyPregnancy.isPregnant() == true) {
+        if (amily.isPregnant() == true) {
             //outputText("DEBUGGER: Already Pregnant")
             return;
         }
@@ -2810,12 +2791,12 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
         if (gameFlags[FOLLOWER_AT_FARM_AMILY] != 0) return;
 
         //25% + gradually increasing cumQ bonus
-        if (rand(4) == 0 || player.cumQ() > rand(1000)) {
-            AmilyScene.amilyPregnancy.eventFill(INCUBATION_AMILY_EVENT);
-            AmilyScene.amilyPregnancy.knockUpForce(PREGNANCY_PLAYER, INCUBATION_MOUSE - 182);
-            timeAware.push(AmilyScene.amilyPregnancy);
+        //if (rand(4) == 0 || player.cumQ() > rand(1000)) {
 
-            }
+            amily.knockUpForce(PREGNANCY_PLAYER, INCUBATION_MOUSE - 182, INCUBATION_AMILY_EVENT);
+
+
+          //  }
 
 
 
@@ -2946,7 +2927,7 @@ AmilyScene.pcBirthsAmilysKidsQuestVersion = function() {
 
     outputText("You are eager to comply, though your last thought as you sink into unconsciousness is to wonder what Amily wants to talk about.");
         gameFlags[PC_TIMES_BIRTHED_AMILYKIDS]++;
-        playerPregnancy.knockUpForce(0,0); // May not need this
+        player.knockUpForce(0,0); // May not need this
     //To part 2!
     doNext(AmilyScene.postBirthingEndChoices);
     return;
@@ -2962,7 +2943,7 @@ outputText(((gameFlags[AMILY_NOT_FURRY]==0)?", naked, pink, and totally hairless
 outputText("Soon, you are back to your old self again, lying down in exhaustion with Amily sitting nearby, your many rambunctious offspring already starting to walk and play around you.<br><br>");
 
 outputText("\"<i>Look at them all. You... I never thought it would turn out this way, but you're helping my dream to come true. Thank you,</i>\" Amily tells you sincerely. You're too exhausted to keep your eyes open for long, but she promises to stay in touch and, even as you fall asleep, she's gathering up your children and taking them away.");
-    playerPregnancy.knockUpForce(0,0); // May not need this
+    player.knockUpForce(0,0); // May not need this
 };
 
 AmilyScene.postBirthingEndChoices = function() {
@@ -3038,7 +3019,7 @@ outputText("Amily reels, heartstruck, her expression making it clear that her he
 AmilyScene.meetAmilyAsACorruptAsshat = function () {
    clearOutput();
             outputText("Curious about how Amily is holding up, you head back into the ruined village. This time, you don't bother making any secret of your presence, hoping to attract Amily's attention quicker. After all, she did say that the place is basically empty of anyone except her, and you can handle a measly Imp or Goblin.<br><br>");
-            switch (AmilyScene.amilyPregnancy.pregnancyEventCounter) {
+            switch (amily.pregnancyEventNum) {
                 case 1:
                 case 2:
                 case 3:
@@ -3931,7 +3912,7 @@ AmilyScene.rapeCorruptAmily4Epilogue = function () {
 //Add corrupted amily flag here
             gameFlags[AMILY_FOLLOWER] = 2;
 //Change to normal mouse pregnancy
-            if (playerPregnancy.pregnancyTypeFlag == PREGNANCY_AMILY) playerPregnancy.knockUpForce(PREGNANCY_MOUSE, playerPregnancy.pregnancyIncubationFlag);
+            if (player.pregnancyType == PREGNANCY_AMILY) player.knockUpForce(PREGNANCY_MOUSE, player.pregnancyIncubation);
 //Set other flags if Amily is moving in for the first time
 //if (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00173] == 0) { //Corruption freakout flag. Not sure if we need to wrap it like this
             gameFlags[AMILY_CUP_SIZE] = 5;

--- a/js/scenes/npcs/amily.js
+++ b/js/scenes/npcs/amily.js
@@ -10,41 +10,36 @@ addToGameFlags(AMILY_MET, AMILY_MET_AS, AMILY_PC_GENDER, AMILY_OFFER_ACCEPTED, A
 
 /*
 
- Changes to make:
+Changes/Upgrades to make:
 
- The initial male meeting offers a rejection option because she's a furry. See amilyNoFur(). Part of the text for that option reveals the ingredients necessary to defur Amily. However, players don't see these ingredients until much later in the game. Amily is often encountered early. How is the player going to know what the ingredients are? This scene is possible several times throughout the code.
+Upgrade - The initial male meeting offers a rejection option because she's a furry. See amilyNoFur(). Part of the text for that option reveals the ingredients necessary to defur Amily. However, players don't see these ingredients until much later in the game. Amily is often encountered early. How is the player going to know what the ingredients are? This scene is possible several times throughout the code. Possible solution. If player goes so far as to reach the Desperate Amily scenes and then rejects her for furriness, I can see her telling the player how to change her. Amily obviously wants the player by this point.
 
- Possible solution. If player goes so far as to reach the Desperate Amily scenes and then rejects her for furriness, I can see her telling the player how to change her. Amily obviously wants the player by this point.
+Upgrade - Need to correct references to leaving the area for good since Shouldra is a part of the town ruins. That code was probably put in before she was put in.
 
- Need to correct references to leaving the area for good since Shouldra is a part of the town ruins. That code was probably put in before she was put in.
+Upgrade - Probably need author permission, but the high-affection sex path could use some expanding. It can take quite a while to get to five litters and having just a few scene variants pop each time is annoying. The lower-affection paths have multiple choices.
 
- Probably need author permission, but the high-affection sex path could use some expanding. It can take quite a while to get to five litters and having nearly the same scene pop each time is annoying. The lower-affection paths have multiple choices.
+Upgrade - Rewrite the pepper part of the conversation tree to not be so generic.
 
- First time Amily Lesbian scene works well, but the code immediately has Amily jump to becoming a herm. This locks out subsequent lesbian scenes in the town ruins. Leaving code as is for now, but a simple affection check should do it. Also, lesbian sex and herm sex with Amily doesn't increase her affection at all. I feel this should be changed.
+Upgrade - Change conversation tree options to match only the ones the player has had an encounter with. Use the codex flags to determine what the player has seen.
 
- undefined error in amilyHermOnFemalePC(). Just have to click next to get past it, but it is something to investigate.
+Upgrade - Giant Bee conversation: Amily says she's been willing to host giant bee eggs on occasion, but will pointedly remind the player she was a virgin when they met. And the player makes no comment about HOW this is possible? Unless anal pregnancy is a thing in Ingnam, this seems like a strange reaction.
 
- Something is wrong in the first time scenes. The program is choking on (player.cocks[0].cockLength >= 14) when it didn't before.
+Upgrade - First time Amily Lesbian scene works well, but the code immediately has Amily jump to becoming a herm. This locks out subsequent lesbian scenes in the town ruins. Leaving code as is for now, but a simple affection check should do it.
 
- Check gender flag checking.
+Upgrade - Lesbian sex and herm sex with Amily doesn't increase her affection at all. I feel this should be changed.
 
- Rewrite the pepper part of the conversation tree.
 
- Change conversation tree options to match only the ones the player has had an encounter with. Use the codex flags to determine what the player has seen.
+ Test - Player Pregnancy with Amily
 
- Gender switching convos need to be checked. Need to make a gender change scene debugging thing in the Camp code.
+ Test - Check gender flag checking. Gender switching convos need to be checked. Need to make a gender change scene debugging thing in the Camp code.
 
- Giant Bee conversation: Amily says she's been willing to host giant bee eggs on occasion, but will pointedly remind the player she was a virgin when they met. And the player makes no comment about HOW this is possible? Unless anal pregnancy is a thing in Ingnam, this seems like a strange reaction.
+ Test - Defurring Code
 
- Figure out how to remove the purified incubus draft from the player's inventory when making Amily a herm.
+Fix Appearance flags for the endings
 
  Fix all tooltip entries (low priority)
 
- Fix entries in main Amily function for combat.
-
  Go through completed Amily list and find out everything that's been commented out. Fix or remove.
-
- There are a bunch of flags set when Amily becomes a follower, but they're echoed in her combat function. Should we set the gameFlags or just reset the variables in the combat function? It looks like they're used for her appearance in camp.
 
  */
 
@@ -54,11 +49,19 @@ addToGameFlags(AMILY_MET, AMILY_MET_AS, AMILY_PC_GENDER, AMILY_OFFER_ACCEPTED, A
 
 //NEEDS PLAYER/CREATURE VARS
 function Amily() {
+
+    // Name and References
     this.a = "";
-    this.short = "Amily";
+    this.name = "Amily";
+    this.refName = this.name;
     //this.imageName = "amily";
-    this.long = "You are currently fighting Amily. The mouse-morph is dressed in rags and glares at you in rage, knife in hand. She keeps herself close to the ground, ensuring she can quickly close the distance between you two or run away.";
-    // this.plural = false;
+    this.battleDesc = "You are currently fighting Amily. The mouse-morph is dressed in rags and glares at you in rage, knife in hand. She keeps herself close to the ground, ensuring she can quickly close the distance between you two or run away.";
+    this.isAre = "is";
+    this.heShe = "she";
+    this.himHer = "her";
+    this.hisHer = "her";
+
+    //Appearance
     this.createVagina(false, VAGINA_WETNESS_NORMAL, VAGINA_LOOSENESS_NORMAL);
     this.createStatusEffect(StatusEffects.BonusVCapacity, 48, 0, 0, 0);
     this.createBreastRow(Appearance.breastCupInverse("C"));
@@ -69,9 +72,10 @@ function Amily() {
     this.buttRating = BUTT_RATING_TIGHT;
     this.skinTone = "tawny";
     this.skinType = SKIN_TYPE_FUR;
-    //this.skinDesc = Appearance.Appearance.DEFAULT_SKIN_DESCS[SKIN_TYPE_FUR];
     this.hairColor = "brown";
     this.hairLength = 5;
+
+    //Stats
     this.str = 20;
     this.tou = 30;
     this.spe = 85;
@@ -79,24 +83,31 @@ function Amily() {
     this.lib = 45;
     this.sens = 45;
     this.cor = 10;
+
+    //Combat stats
     this.weapon.equipmentName = "knife";
     this.weapon.verb = "slash";
-    //this.weaponAttack = 6;
+    this.weapon.Attack = 6;
     this.armorName = "rags";
-    //this.armorDef = 1;
+    this.armor.defense = 1;
     this.bonusHP = 20;
     this.lust = 20;
     this.lustVuln = 0.85;
     this.level = 4;
     this.gems = 2 + rand(5);
+    this.clearDrops();
     //this.drop = NO_DROP;
     //checkMonster();
+    this.victory = AmilyScene.rapeCorruptAmily1;
+    this.defeat = cleanupAfterCombat;
 }
+Amily.prototype = new Creature();
+Amily.prototype.constructor = Amily;
 
 var sexForced = false; // Used to get around a nasty bug.
 
 
-// Used for later checks when Amily is a follower.
+// Used for later checks when Amily is a follower. - COMPLETE
 AmilyScene.amilyFollower = function() {
     if (gameFlags[AMILY_FOLLOWER] > 0) {
         //Amily not a follower while visiting Urta
@@ -107,7 +118,7 @@ AmilyScene.amilyFollower = function() {
     }
 };
 
-// A check function to see if Amily is corrupt or not.
+// A check function to see if Amily is corrupt or not. - COMPLETE
 AmilyScene.amilyCorrupt = function() {
     if (gameFlags[AMILY_FOLLOWER] == 2) {
         return true;
@@ -152,8 +163,8 @@ AmilyScene.start = function () {
         doNext(Camp.returnToCampUseOneHour);
         return;
     }
+    
     // Amily can't be encountered due to worms, high initial corruption, or has flipped out due to the player's increasing corruption
-
     if (gameFlags[AMILY_GROSSED_OUT_BY_WORMS] == 1 || player.cor > 25 || gameFlags[AMILY_CORRUPT_FLIPOUT] > 0) {
         outputText("You enter the ruined village cautiously. There are burnt-down houses, smashed-in doorways, ripped-off roofs... everything is covered with dust and grime. For hours you explore, but you cannot find any sign of another living being, or anything of value. The occasional footprint from an imp or a goblin turns up in the dirt, but you don't see any of the creatures themselves. It looks like time and passing demons have stripped the place bare since it was originally abandoned. Finally, you give up and leave. You feel much easier when you're outside of the village – you had the strangest sensation of being watched while you were in there.");
         doNext(Camp.returnToCampUseOneHour);
@@ -198,7 +209,6 @@ AmilyScene.start = function () {
 
 
     //If Amily is ready to give birth, do this
-
     if (AmilyScene.amilyPregnancy.isPregnant() == true && AmilyScene.amilyPregnancy.pregnancyIncubationFlag == 0) {
         AmilyScene.amilyGivesBirth();
         AmilyScene.amilyPregnancy.knockUpForce(0, 0); //Clear Pregnancy
@@ -314,6 +324,7 @@ AmilyScene.start = function () {
                 addButton(3, "Blunt Reject", AmilyScene.desperateAmilyPleaTurnDownBlunt, null, null, null, "Tooltip to be added");
             } else {
                 AmilyScene.amilyStandardMeeting();
+                return;
             }
         }
 
@@ -350,28 +361,29 @@ AmilyScene.start = function () {
                 //Set flag for 'last gender met as'
                 gameFlags[AMILY_PC_GENDER] = player.gender;
                 doNext(Camp.returnToCampUseOneHour);
-                //return;
+                return;
             }
             //Lesbo lovin confession!
             if (gameFlags[AMILY_CONFESSED_LESBIAN] == 0 && gameFlags[AMILY_AFFECTION] >= 25) {
                 AmilyScene.amilyLesbian();
-                //return;
+                return;
             }
 
             //If PC shot down love confession, cap affection at 35 and re-offer?
             if (gameFlags[AMILY_AFFECTION] > 35 && gameFlags[AMILY_CONFESSED_LESBIAN] == 1) {
                 gameFlags[AMILY_AFFECTION] = 35;
                 AmilyScene.amilyLesbian();
-                //return;
+                return;
             }
 
             //Amily totally grows a wang for you once she loves you
 
             if (gameFlags[AMILY_CONFESSED_LESBIAN] == 2 && gameFlags[AMILY_WANG_LENGTH] == 0) {
                 AmilyScene.amilyPostConfessionGirlRemeeting();
-                //return;
+                return;
             } else {
                 AmilyScene.amilyStandardMeeting();
+                return;
             }
 
         }
@@ -413,17 +425,19 @@ AmilyScene.start = function () {
                 //Set flag for 'last gender met as'
                 gameFlags[AMILY_PC_GENDER] = player.gender;
                 doNext(Camp.returnToCampUseOneHour);
+                return;
             }
             if (((gameFlags[AMILY_AFFECTION] >= 15 && rand(3) == 0) || gameFlags[AMILY_AFFECTION] >= 20) && gameFlags[AMILY_HERM_QUEST] == 0) {
                 AmilyScene.whyNotHerms();
-                //return;
+                return;
             }
 
             if (gameFlags[AMILY_HERM_QUEST] == 1) {
                 AmilyScene.hermRenegotiate();
-                //return;
+                return;
             } else {
                 AmilyScene.amilyStandardMeeting();
+                return;
             }
 
         }
@@ -490,20 +504,21 @@ AmilyScene.start = function () {
                 //Set flag for 'last gender met as'
                 gameFlags[AMILY_PC_GENDER] = player.gender;
                 doNext(Camp.returnToCampUseOneHour);
-                //return;
+                return;
             } else {
                 AmilyScene.amilyStandardMeeting();
+                return;
             }
         }
         //Reach this, show default explore message and return to camp.
         else {
             AmilyScene.amilyMeetingFailed();
+            return;
         }
 
-    }
-    ;
+    };
 
-// Standard meeting loop after first time - NEED SPRITE IMAGE AND PREGNANCY EVENTS TO FINISH
+// Standard meeting loop after first time - COMPLETE
     AmilyScene.amilyStandardMeeting = function () {
         clearOutput();
         // Amily does NOT like seeing the player change gender
@@ -597,7 +612,7 @@ AmilyScene.start = function () {
     };
 //MALE MEETINGS AFTER INITIAL REJECTION
 
-// Male PC rejected Amily's offer, meets her again - NEED SPRITE IMAGE TO FINISH
+// Male PC rejected Amily's offer, meets her again - COMPLETE
     AmilyScene.amilyRemeetingContinued = function () {
         clearOutput();
 
@@ -611,7 +626,7 @@ AmilyScene.start = function () {
 
     };
 
-// Accept offer the second time, move to sex loops. - NEED SPRITE IMAGE TO FINISH
+// Accept offer the second time, move to sex loops. - COMPLETE
     AmilyScene.secondTimeAmilyOfferedAccepted = function () {
         clearOutput();
 
@@ -621,7 +636,7 @@ AmilyScene.start = function () {
         doNext(AmilyScene.amilySexHappens);
     };
 
-// Refuse offer politely a second time. No affection boost. No change to the encounters. - NEED SPRITE IMAGE TO FINISH
+// Refuse offer politely a second time. No affection boost. No change to the encounters. - COMPLETE
     AmilyScene.secondTimeAmilyRefuseAgain = function () {
         clearOutput();
 
@@ -633,7 +648,7 @@ AmilyScene.start = function () {
         doNext(Camp.returnToCampUseOneHour);
     };
 
-// Talking to Amily again after offer refusal - NEED SPRITE IMAGE TO FINISH
+// Talking to Amily again after offer refusal - COMPLETE
     AmilyScene.repeatAmilyTalk = function () {
         clearOutput();
 
@@ -642,7 +657,7 @@ AmilyScene.start = function () {
         doNext(AmilyScene.amilyConversationStart);
     };
 
-// This text needs updating. Looks like it was originally going to shut out the whole ruins, but there could still be racks and/or Shouldra encounters the player would want to encounter. Leaving text as is for now.
+// This text needs updating. Looks like it was originally going to shut out the whole ruins, but there could still be racks and/or Shouldra encounters the player would want to encounter. Leaving text as is for now. Otherwise Complete.
 // Shuts off Amily encounters
     AmilyScene.tellAmilyToGetLost = function () {
 
@@ -658,7 +673,7 @@ AmilyScene.start = function () {
 
 // IF MALE OFFER IS ACCEPTED FIRST TIME
 
-// Male PC accepts Amily's offer eagerly. (Consider changing this response to Lusty. It's a bit beyond eager...) - NEED SPRITE IMAGE TO FINISH
+// Male PC accepts Amily's offer eagerly. (Consider changing this response to Lusty. It's a bit beyond eager...) - COMPLETE
     AmilyScene.acceptAmilysOfferEagerly = function () {
         clearOutput();
         menu();
@@ -681,8 +696,9 @@ AmilyScene.start = function () {
         //[/ Go to [First Time Sex]]
         doNext(AmilyScene.amilySexHappens);
 
-    };
-// Male PC accepts Amily's offer hesitantly. - NEED SPRITE IMAGE TO FINISH
+    }; 
+
+// Male PC accepts Amily's offer hesitantly. - COMPLETE
     AmilyScene.acceptAmilysOfferHesitantly = function () {
         clearOutput();
         menu();
@@ -708,7 +724,8 @@ AmilyScene.start = function () {
         doNext(AmilyScene.amilySexHappens);
 
     };
-// Refuse Amily's Offer. Impress her! - NEED SPRITE IMAGE TO FINISH
+
+// Refuse Amily's Offer. Impress her! - COMPLETE
     AmilyScene.refuseAmilysOffer = function () {
         clearOutput();
         menu();
@@ -730,7 +747,8 @@ AmilyScene.start = function () {
         player.modStats("lib", -5);
         doNext(Camp.returnToCampUseOneHour);
     };
-// Refuse Amily because she's a mouse and mice are gross. - NEED SPRITE IMAGE TO FINISH
+
+// Refuse Amily because she's a mouse and mice are gross. - COMPLETE
     AmilyScene.amilyNoFur = function () {
         clearOutput();
         menu();
@@ -745,9 +763,10 @@ AmilyScene.start = function () {
         outputText("\"<i>Well, uh... bye,</i>\" Amily concludes, whirling around and walking away.  You can't be sure, but it seems like she's exaggerating the sway of her hips a bit.  You don't think much of it, heading back toward camp and beginning to formulate a concoction to de-mouse your potential breeding partner.  Perhaps... a <b>golden seed</b> for a human face, a <b>black egg</b> to get rid of the fur, and some <b>purified succubus milk</b> to round things off.  You make a mental note to remember those ingredients, for they won't show up again and you'd feel positively silly if you somehow completely forgot them.<br><br>");
         doNext(Camp.returnToCampUseOneHour);
     };
+
 //MALE DESPERATE AMILY ENCOUNTERS
 
-//Accept Amily Desperate Plea - NEED SPRITE IMAGE TO FINISH
+//Accept Amily Desperate Plea - COMPLETE
     AmilyScene.desperateAmilyPleaAcceptHer = function () {
         clearOutput();
 
@@ -760,7 +779,7 @@ AmilyScene.start = function () {
         doNext(AmilyScene.amilySexHappens);
     };
 
-//Let Amily Down Gently, shuts off her encounters - NEED SPRITE AND TEL'ADRE to finish
+//Let Amily Down Gently, shuts off her encounters - NEED TEL'ADRE TO FINISH
     AmilyScene.desperateAmilyPleaTurnDown = function () {
         clearOutput();
 
@@ -782,7 +801,7 @@ AmilyScene.start = function () {
         doNext(Camp.returnToCampUseOneHour);
     };
 
-//Be an ass and turn her down bluntly- NEED SPRITE IMAGE TO FINISH
+//Be an ass and turn her down bluntly- COMPLETE
     AmilyScene.desperateAmilyPleaTurnDownBlunt = function () {
 
         clearOutput();
@@ -805,7 +824,7 @@ AmilyScene.start = function () {
 
 //FEMALE AMILY ENCOUNTERS
 
-//Lesbian Love Confession:- NEED SPRITE IMAGE TO FINISH
+//Lesbian Love Confession:- COMPLETE
 
     AmilyScene.amilyLesbian = function () {
 
@@ -822,7 +841,7 @@ AmilyScene.start = function () {
         addButton(1, "Let Her Go", AmilyScene.amilyLesbianLetHerGo, null, null, null, "Tooltip added later.");
     };
 
-// Admit you want Lesbian Mouse Lovin
+// Admit you want Lesbian Mouse Lovin - COMPLETE
     AmilyScene.amilyLesbianStopHer = function () {
 
         clearOutput();
@@ -852,7 +871,7 @@ AmilyScene.start = function () {
 
 // HERM PLAYER ENCOUNTERS
 
-// Make Amily a Herm for dual pregnancy action. - NEED SPRITE IMAGE AND PREGNANCY EVENTS AND ITEM CONSUMPTION TO FINISH
+// Make Amily a Herm for dual pregnancy action. - COMPLETE. TEST ITEM CONSUMPTION AT SOME POINT.
     AmilyScene.makeAmilyAHerm = function () {
 
         clearOutput();
@@ -870,20 +889,19 @@ AmilyScene.start = function () {
 
         outputText("Amily is now a hermaphrodite. Her human-like penis is four inches long and one inch thick.<br><br>");
 
-
         outputText("Catching her breath, she " + (AmilyScene.amilyPregnancy.pregnancyEventCounter >= 6 ? "tries to get a look at her new member over her bulging belly. When that fails she runs her hand over it, touching it carefully while maintaining an unreadable expression. Then she stares at you and says, " : "stares at her new appendage with an unreadable expression, then she stares at you.") + " \"<i>Well, now I've got a penis... so that means you're coming with me to let me try it out!</i>\"<br><br>");
 
 
         outputText("You agree  and allow her to begin leading you to the \"<i>bedroom</i>\".");
         gameFlags[AMILY_WANG_LENGTH] = 4;
         gameFlags[AMILY_WANG_GIRTH] = 1;
-        //player.consumeItem(Items.Consumables.IncubiDraftPurified); Need to figure out how to make this work.
+        player.destroyItems(Items.Consumables.IncubiDraftPurified, 1);
         menu();
         //[Herm Amily on Female PC, First Time, scene plays]
         doNext(AmilyScene.amilyHermOnFemalePC);
     };
 
-// Question dislike of herms.
+// Question dislike of herms. - COMPLETE
     AmilyScene.whyNotHerms = function () {
 
         clearOutput();
@@ -914,7 +932,7 @@ AmilyScene.start = function () {
         doNext(Camp.returnToCampUseOneHour);
     };
 
-//"Maybe Herms Aren't So Bad":
+//"Maybe Herms Aren't So Bad": - COMPLETE
     AmilyScene.hermRenegotiate = function () {
 
         clearOutput();
@@ -931,7 +949,7 @@ AmilyScene.start = function () {
 
     };
 
-// Agree to Amily's hermneess.
+// Agree to Amily's hermness. - COMPLETE
     AmilyScene.amilyAgreeHerm = function () {
 
         clearOutput();
@@ -941,7 +959,7 @@ AmilyScene.start = function () {
         doNext(AmilyScene.amilySexHappens);
     };
 
-// Reject Amily's Hermness
+// Reject Amily's Hermness - COMPLETE
     AmilyScene.amilyRejectHerm = function () {
 
         clearOutput();
@@ -1232,13 +1250,11 @@ AmilyScene.start = function () {
         doNext(AmilyScene.amilyStandardMeeting);
     };
 
-    /********
-     *
-     * Conversation starts
-     *
-     *********/
+//---------------
+// Conversation starts
+//---------------
 
-// Opening conversation scene - NEED SPRITE IMAGE TO FINISH, NEED PREGNANCY EVENTS TO FINISH
+// Opening conversation scene - COMPLETE
     AmilyScene.talkToAmily = function () {
         clearOutput();
 
@@ -1279,7 +1295,7 @@ AmilyScene.start = function () {
 
     };
 
-// GIANT CONVERSATION TREE START! - - NEED SPRITE IMAGE TO FINISH
+// GIANT CONVERSATION TREE START! - COMPLETE
     AmilyScene.amilyConversationStart = function () {
         clearOutput();
 
@@ -1746,7 +1762,7 @@ AmilyScene.start = function () {
     };
 
 
-//Talk and then Sex - NEED SPRITE IMAGE AND PREGNANCY EVENTS TO FINISH
+//Talk and then Sex - COMPLETE
     AmilyScene.talkThenSexWithAmily = function () {
         clearOutput();
 
@@ -1836,28 +1852,27 @@ AmilyScene.start = function () {
     };
 
 
-    /*******
-     *
-     * Sex Scenes Start
-     *
-     ********/
+//-----------
+// Sex Scenes Start
+//-----------
+
 
 //MALE
 
-// Kicks off the male sex paths - NEEDS SPRITE IMAGE AND PLAYER COCK TESTING AND PREGNANCY EVENTS TO FINISH
-    AmilyScene.amilySexHappens = function () {
+// Kicks off the male sex paths - COMPLETE, CHECK COCK EVENT THOUGH.
+AmilyScene.amilySexHappens = function () {
         clearOutput();
 
-        //var x = player.cockThatFits(61);
+        var x = player.cockThatFits(61);
         //If too big
-        //if (x == -1 && player.hasCock()) {
-        //   outputText("Amily looks between your legs and doubles over laughing, \"<i>There is no way that thing is fitting inside of me!  You need to find a way to shrink that thing down before we get in bed!</i>\"");
+        if (x == -1 && player.hasCock()) {
+           outputText("Amily looks between your legs and doubles over laughing, \"<i>There is no way that thing is fitting inside of me!  You need to find a way to shrink that thing down before we get in bed!</i>\"");
         // Incredulous cock makes Amily less affectionate!
-        //   gameFlags[AMILY_AFFECTION]--;
-        //    doNext(Camp.returnToCampUseOneHour);
-        //	}
+           gameFlags[AMILY_AFFECTION]--;
+            doNext(Camp.returnToCampUseOneHour);
+        }
         // Sex for the First time
-        //else
+        else
         if (gameFlags[AMILY_FUCK_COUNTER] == 0) {
             gameFlags[AMILY_FUCK_COUNTER]++;
             AmilyScene.amilySexFirstTime();
@@ -1898,102 +1913,100 @@ AmilyScene.start = function () {
 
     };
 
-// Switches sex scenes with Amily depending on gender, pregnancy, and other things - NEEDS LOTS OF WORK TO FINALIZE
-    AmilyScene.determineAmilySexEvent = function () { // May need to force a false boolean to determine if sex is forced
+// Switches sex scenes with Amily depending on gender, pregnancy, and other things - COMPLETE
+AmilyScene.determineAmilySexEvent = function () { // May need to force a false boolean to determine if sex is forced
         // Set the sex variable to none
-        var sex = null;
+
         // Assume Amily isn't forcing you to fuck her.
-        //var forced = false;
         // If sex isn't forced and the player isn't horny enough to fuck, jump out of loop
 
         // FEMALE SCENES
-        /*
-         //If Amily is lesbo lover!
-         if (gameFlags[AMILY_CONFESSED_LESBIAN] > 0 && player.gender == 2) {
-         if (gameFlags[AMILY_WANG_LENGTH] > 0) {
+
+        //If Amily is lesbo lover!
+    if (gameFlags[AMILY_CONFESSED_LESBIAN] > 0 && player.gender == 2) {
+        if (gameFlags[AMILY_WANG_LENGTH] > 0) {
          //If not pregnant, always get fucked!
-         if (!amilyPregnancy.isPregnant) sex = hermilyOnFemalePC;
+            if (!AmilyScene.amilyPregnancy.isPregnant()) AmilyScene.amilyHermOnFemalePC();
          //else 50/50
-         else {
-         if (rand(2) == 0) sex = girlyGirlMouseSex;
-         else sex = hermilyOnFemalePC;
-         }
-         }
+            else {
+            if (rand(2) == 0) AmilyScene.girlyGirlMouseSex();
+            else AmilyScene.amilyHermOnFemalePC();
+                }
+            }
          //LESBO LUVIN!
-         else sex = girlyGirlMouseSex;
-         }
-         */
-        // HERM SCENES
-        /*
-         //If Amily is a herm lover!
-         if (player.gender == 3 && gameFlags[AMILY_HERM_QUEST] == 2) {
-         //Amily is herm too!
-         if (gameFlags[AMILY_WANG_LENGTH] > 0) {
-         //If Amily is not pregnant
-         if (!pregnancy.isPregnant) {
-         //If PC is also not pregnant, 50/50 odds
-         if (!player.isPregnant()) {
-         //Herm Amily knocks up PC
-         if (rand(2) == 0) sex = hermilyOnFemalePC;
-         //PC uses dick on amily
-         else {
-         if (forced) sex = amilySexHappens;
-         else sex = sexWithAmily;
-         }
-         }
-         //If PC is preg, knock up amily.
-         else {
-         if (forced) sex = amilySexHappens;
-         else sex = sexWithAmily;
+         else AmilyScene.girlyGirlMouseSex();
          }
 
-         }
-         //Amily is preg
-         else {
-         //Pc is not
-         if (!player.isPregnant()) sex = hermilyOnFemalePC;
-         //PC is preg too!
-         else {
+        // HERM SCENES
+
+         //If Amily is a herm lover
+    if (player.gender == 3 && gameFlags[AMILY_HERM_QUEST] == 2) {
+         //Amily is herm too!
+        if (gameFlags[AMILY_WANG_LENGTH] > 0) {
+         //If Amily is not pregnant
+            if (!AmilyScene.amilyPregnancy.isPregnant()) {
+         //If PC is also not pregnant, 50/50 odds
+                if (!player.pregnancy.isPregnant()) {
          //Herm Amily knocks up PC
-         if (rand(2) == 0) sex = hermilyOnFemalePC;
+                    if (rand(2) == 0) AmilyScene.amilyHermOnFemalePC();
          //PC uses dick on amily
-         else {
-         if (forced) sex = amilySexHappens;
-         else sex = sexWithAmily;
-         }
-         }
-         }
-         }
+                    else {
+                        if (sexForced) AmilyScene.amilySexHappens();
+                        else AmilyScene.sexWithAmily();
+                    }
+                }
+         //If PC is preg, knock up amily.
+                else {
+                    if (sexForced) AmilyScene.amilySexHappens();
+                    else AmilyScene.sexWithAmily();
+                }
+
+            }
+         //Amily is preg
+            else {
+                //Pc is not
+                if (!player.pregnancy.isPregnant()) AmilyScene.amilyHermOnFemalePC();
+                //PC is preg too!
+                else {
+                    //Herm Amily knocks up PC
+                    if (rand(2) == 0) AmilyScene.amilyHermOnFemalePC();
+                    //PC uses dick on amily
+                    else {
+                        if (sexForced) AmilyScene.amilySexHappens();
+                        else AmilyScene.sexWithAmily();
+                    }
+                }
+            }
+        }
          //Amily still girl!
-         else {
+        else {
          //Not pregnant? KNOCK THAT SHIT UP
-         if (!pregnancy.isPregnant) sex = sexWithAmily;
+            if (!player.pregnancy.isPregnant()) AmilyScene.sexWithAmily();
          //Pregnant?  Random tribbing!
-         else {
+            else {
          //Lesbogrind
-         if (rand(2) == 0) sex = girlyGirlMouseSex;
+                if (rand(2) == 0) AmilyScene.girlyGirlMouseSex();
          //Fuck!
-         else {
-         if (forced) sex = amilySexHappens;
-         else sex = sexWithAmily;
+                else {
+                    if (sexForced) AmilyScene.amilySexHappens();
+                    else AmilyScene.sexWithAmily();
+                }
+            }
          }
-         }
-         }
-         }
-         */
+    }
+
 
         // MALE SCENES - CHECK THESE TWO SCENES
 
-        if (player.gender == 1) {
-            //if (forced == true) amilySexHappens();
-            //else
-            AmilyScene.sexWithAmily();
-        }
+    if (player.gender == 1) {
+        if (sexForced == true) AmilyScene.amilySexHappens();
+        else AmilyScene.sexWithAmily();
+    }
 
-    };
+};
 
 
-// Amily response to you proposing sex in later meetings - NEEDS SPRITE AND PREGNANCY EVENTS TO FINISH
+// Amily response to you proposing sex in later meetings - COMPLETE
     AmilyScene.sexWithAmily = function () {
         clearOutput();
 
@@ -2086,15 +2099,15 @@ AmilyScene.start = function () {
      / Male Low Affection Amily Sex Path
      ******/
 
-// Low Affection Section 1 Choice 1 - NEED SPRITE TO FINISH
+// Low Affection Section 1 Choice 1 - COMPLETE
     AmilyScene.amilySexBusiness = function () {
         clearOutput();
 
-        outputText("Allowing Amily to take care of her clothes, you hastily remove your own " + player.armorName + ". Once the two of you are naked in front of each other, Amily looks you up and down, and then sniffs - not in disdain, but honestly trying to get a good scent of you. You speculate that this is some kind of check to see that you haven't somehow managed to become corrupted since last you met.<br><br>");
+        outputText("Allowing Amily to take care of her clothes, you hastily remove your own " + player.armor.equipmentName + ". Once the two of you are naked in front of each other, Amily looks you up and down, and then sniffs - not in disdain, but honestly trying to get a good scent of you. You speculate that this is some kind of check to see that you haven't somehow managed to become corrupted since last you met.<br><br>");
         AmilyScene.amilySexPtII();
     };
 
-// Low Affection Section 1Choice 2 - NEED SPRITE TO FINISH
+// Low Affection Section 1Choice 2 - COMPLETE
     AmilyScene.amilySexPlaytimeFirst = function () {
         clearOutput();
 
@@ -2104,14 +2117,14 @@ AmilyScene.start = function () {
 
         outputText("You simply smile back at her, and then gently begin to undress her, stopping her from lifting a finger to take off her clothes as you playfully remove them for her. At least, as playfully as you can, given how simple her garb is. The mouse-girl is confused, and she blushes a bit, but you think she's enjoying the attention, and you take this as an opportunity to gently scratch the base of her tail and tickle the rim of her ears with your fingers, the latter of which makes her giggle despite herself. Once she is standing nude before you, you begin to take off your own clothes. However, to your surprise, it is her turn to stop you.<br><br>");
 
-        outputText("\"<i>Fair is fair.</i>\" She growls, but she's blushing faintly. Clumsy with unfamiliarity, she nonetheless does her best to remove your " + player.armorName + " in as erotic a fashion as she can manage, and you catch her nimble little fingers hesitantly stroking across the more interesting parts of your anatomy more than once. When you stand before her naked, she carefully looks you over and takes several deep breaths through her nose.<br><br>");
+        outputText("\"<i>Fair is fair.</i>\" She growls, but she's blushing faintly. Clumsy with unfamiliarity, she nonetheless does her best to remove your " + player.armor.equipmentName + " in as erotic a fashion as she can manage, and you catch her nimble little fingers hesitantly stroking across the more interesting parts of your anatomy more than once. When you stand before her naked, she carefully looks you over and takes several deep breaths through her nose.<br><br>");
 
         outputText("\"<i>Just making sure that you haven't... you know, picked up something you shouldn't.</i>\" She explains softly.<br><br>");
         player.changeLust(5);
         AmilyScene.amilySexPtII();
     };
 
-// Low Affection Section 2 - NEED SPRITE AND WORM FUNCTIONS TO FINISH
+// Low Affection Section 2 - NEED WORM FUNCTIONS TO FINISH
     AmilyScene.amilySexPtII = function () {
 
 
@@ -2132,7 +2145,7 @@ AmilyScene.start = function () {
 
     };
 
-// Low Affection Section 2 Choice 1 - NEED SPRITE
+// Low Affection Section 2 Choice 1 - COMPLETE
     AmilyScene.amilySexSitAndWatch = function () {
         clearOutput();
 
@@ -2143,7 +2156,7 @@ AmilyScene.start = function () {
         AmilyScene.amilySexPartIII();
     };
 
-// Low Affection Section 2 Choice 2 - NEED SPRITE
+// Low Affection Section 2 Choice 2 - COMPLETE
     AmilyScene.amilySexCaressHer = function () {
         clearOutput();
 
@@ -2152,7 +2165,7 @@ AmilyScene.start = function () {
         addButton(1, "Kiss Her", AmilyScene.amilySexKiss, null, null, null, "Maybe I could show her how it's done?");
     };
 
-// Low Affection Section 2 Choice 2.1 - NEED SPRITE
+// Low Affection Section 2 Choice 2.1 - COMPLETE
     AmilyScene.amilySexRefrainKiss = function () {
         clearOutput();
 
@@ -2162,7 +2175,7 @@ AmilyScene.start = function () {
         AmilyScene.amilySexPartIII();
     };
 
-// Low Affection Section 2 Choice 2.2 - NEED SPRITE
+// Low Affection Section 2 Choice 2.2 - COMPLETE
     AmilyScene.amilySexKiss = function () {
         clearOutput();
 
@@ -2174,7 +2187,7 @@ AmilyScene.start = function () {
         AmilyScene.amilySexPartIII();
     };
 
-// Low Affection Section 3 (final) - NEED SPRITE AND PLAYER COCK TO FINISH
+// Low Affection Section 3 (final) - COMPLETE
     AmilyScene.amilySexPartIII = function () {
         var x = player.cockThatFits(61);
 
@@ -2210,7 +2223,7 @@ AmilyScene.start = function () {
      * Male Medium Affection Amily Sex Path
      ***********/
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilySexStepIn = function () {
         clearOutput();
 
@@ -2218,7 +2231,7 @@ AmilyScene.start = function () {
         AmilyScene.amilySexMidPartII();
     };
 
-// NEED SPRITE AND PREGNANCY EVENTS
+// COMPLETE
     AmilyScene.amilySexEnjoyShow = function () {
         clearOutput();
 
@@ -2228,7 +2241,7 @@ AmilyScene.start = function () {
         AmilyScene.amilySexMidPartII();
     };
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilySexMidPartII = function () {
         player.changeLust(5);
 
@@ -2238,27 +2251,27 @@ AmilyScene.start = function () {
         addButton(1, "Business", AmilyScene.amilySexGetTheFunStarted, null, null, null, "She doesn't need to tease you anymore to get you going! Let's get to the fun part...");
     };
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilySexYouStrip = function () {
         clearOutput();
 
         var x = player.cockThatFits(61);
-        outputText("It is your turn to give her a mischievous smile back. Feeling turned on and excited, and remembering the elders in the village telling you that fair is only fair, you decide to give her a little show of her own. Standing up, you tilt your head back and thrust out your chest, trying to look enticing. As Amily watches, at first bemused and then pleased, you slowly strip off your " + player.armorName + ", working hard to make it as sensual and suggestive as possible. You show off your body for her, leisurely stroking your own limbs and down your midriff to finally reveal that which lies inside your pants; your " + player.cockDescript(x) + ". Amily is definitely appreciative of the show.<br><br>");
+        outputText("It is your turn to give her a mischievous smile back. Feeling turned on and excited, and remembering the elders in the village telling you that fair is only fair, you decide to give her a little show of her own. Standing up, you tilt your head back and thrust out your chest, trying to look enticing. As Amily watches, at first bemused and then pleased, you slowly strip off your " + player.armor.equipmentName + ", working hard to make it as sensual and suggestive as possible. You show off your body for her, leisurely stroking your own limbs and down your midriff to finally reveal that which lies inside your pants; your " + player.cockDescript(x) + ". Amily is definitely appreciative of the show.<br><br>");
         AmilyScene.amilySexMidPartIII();
         //continueWithMoreMidLevelAmilySex();
     };
 
-// NEED SPRITE, PLAYER VARIABLE CHECK, PLAYER COCK
+// COMPLETE
     AmilyScene.amilySexGetTheFunStarted = function () {
         clearOutput();
 
         var x = player.cockThatFits(61);
-        outputText("Too horny to think of anything else than what lies ahead, you hastily remove your " + player.armorName + ".  Amily smiles at what she can see, enjoying the sight of your body and your " + player.cockDescript(x) + "<br><br>");
+        outputText("Too horny to think of anything else than what lies ahead, you hastily remove your " + player.armor.equipmentName + ".  Amily smiles at what she can see, enjoying the sight of your body and your " + player.cockDescript(x) + "<br><br>");
         AmilyScene.amilySexMidPartIII();
         //continueWithMoreMidLevelAmilySex();
     };
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilySexMidPartIII = function () {
         player.changeLust(5);
 
@@ -2268,7 +2281,7 @@ AmilyScene.start = function () {
 
     };
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilySexPlayAlong = function () {
         outputText("", true);
 
@@ -2279,7 +2292,7 @@ AmilyScene.start = function () {
         AmilyScene.amilySexMidPartIV();
     };
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilySexWorkToPlease = function () {
         clearOutput();
 
@@ -2289,7 +2302,7 @@ AmilyScene.start = function () {
         AmilyScene.amilySexMidPartIV();
     };
 
-// NEED SPRITE, POSSIBLE AFFECTION GAIN
+// POSSIBLE AFFECTION GAIN?
     AmilyScene.amilySexMidPartIV = function () {
 
         outputText("Quite spent from your lovemaking, Amily sinks down on your breast, smiles at you and slowly dozes off. You also drift off to sleep soon after. Some time later, you wake up to find her already putting on her clothes again.<br><br>");
@@ -2303,7 +2316,7 @@ AmilyScene.start = function () {
 
     };
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilySexSayGoodbye = function () {
 
         clearOutput();
@@ -2311,7 +2324,7 @@ AmilyScene.start = function () {
         doNext(Camp.returnToCampUseOneHour);
     };
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilySexStayAwhile = function () {
 
         clearOutput();
@@ -2325,7 +2338,7 @@ AmilyScene.start = function () {
      * Male High Affection Amily Sex Path
      **********/
 
-//[High Affection - Non-Pregnant/Slightly Pregnant] -- NEED SPRITE, PREGNANCY, PLAYER COCK
+//[High Affection - Non-Pregnant/Slightly Pregnant] -- COMPLETE
     AmilyScene.amilyHighAffectionSex = function () {
 
 
@@ -2444,7 +2457,7 @@ AmilyScene.start = function () {
     };
 
 
-//High Affection - Very Pregnant
+//High Affection - Very Pregnant - COMPLETE
     AmilyScene.fuckAmilyPreg = function () {
         clearOutput();
         outputText("Amily leads you by the hand to her hiding place as quickly as possible... which is a relatively brisk walking speed. You don't rush her or anything, understanding how the heavy bump on her belly is slowing her down, moving side-by-side at the same pace.  You try to help Amily over the difficult terrain facing her.");
@@ -2489,7 +2502,7 @@ AmilyScene.start = function () {
 
 //FEMALE SEX
 
-// First time and subsequent times. Some problems with this scene. See notes. - NEED SPRITE
+// First time and subsequent times. Some problems with this scene. See notes. - COMPLETE
     AmilyScene.girlyGirlMouseSex = function () {
 
         clearOutput();
@@ -2501,7 +2514,7 @@ AmilyScene.start = function () {
 
         outputText("You smile at her, place a hand gently under her chin, and then draw her in closely. You kiss her, deeply and warmly, not trying to force anything but letting her be drawn into it of her own accord. As she starts to kiss you back, you gently reach into her shirt and begin to caress her small, tender breasts. As you stroke and tease the sensitive flesh, rubbing a thumb enticingly around each nipple, Amily moans, and her tail suddenly wraps convulsively around your " + player.leg() + ", making it quite clear that she's enjoying this and getting ready.<br><br>");
 
-        outputText("Slowly you lead her to her bedding, and it is only when she is on her back that you break off the kiss. Amily looks dazed for a few moments, and then grins at you. \"<i>Wow.</i>\" You smile in response and start to remove your " + player.armorName + " - Amily sees this and hurriedly starts to pull off her own tattered rags. Once the two of you are naked, you give her one last kiss before you gently sit atop her, facing backwards. You slowly lie yourself down onto her, giving you a perfect view of her pink, naked pussy, and allowing her to come face to face with your own " + player.vaginaDescript(0) + ".<br><br>");
+        outputText("Slowly you lead her to her bedding, and it is only when she is on her back that you break off the kiss. Amily looks dazed for a few moments, and then grins at you. \"<i>Wow.</i>\" You smile in response and start to remove your " + player.armor.equipmentName + " - Amily sees this and hurriedly starts to pull off her own tattered rags. Once the two of you are naked, you give her one last kiss before you gently sit atop her, facing backwards. You slowly lie yourself down onto her, giving you a perfect view of her pink, naked pussy, and allowing her to come face to face with your own " + player.vaginaDescript(0) + ".<br><br>");
 
         if (gameFlags[AMILY_TIMES_FUCKED_FEMPC] == 0) outputText("\"<i>...I'm supposed to lick you there, right?</i>\" Amily asks, hesitantly. You smirk and promptly give her own sex a long, sloppy lick of your own. She squeaks in shock and then clumsily licks you in return.<br><br>");
         else outputText("Amily needs no instructions and plunges her tongue as deeply as it can go into your sex. You yelp in shock, which makes Amily's tail wave happily, and, grinning mischievously, you return the favor.<br><br>");
@@ -2525,7 +2538,7 @@ AmilyScene.start = function () {
 // Amily turns Herm for you scenes.
 
 
-// NEED SPRITE
+// COMPLETE
     AmilyScene.amilyPostConfessionGirlRemeeting = function () {
 
         clearOutput();
@@ -2546,7 +2559,7 @@ AmilyScene.start = function () {
     };
 
 
-// Accept Herm Amily's offer - NEED SPRITE
+// Accept Herm Amily's offer - COMPLETE
     AmilyScene.acceptHermAmily = function () {
 
         clearOutput();
@@ -2557,7 +2570,7 @@ AmilyScene.start = function () {
     };
 
 
-// Reject Amily Herm offer. Closes encounter off - NEED SPRITE
+// Reject Amily Herm offer. Closes encounter off - COMPLETE
     AmilyScene.denyHermAmily = function () {
 
         clearOutput();
@@ -2569,11 +2582,13 @@ AmilyScene.start = function () {
         doNext(Camp.returnToCampUseOneHour);
     };
 
-// NEED SPRITE, cuntChange FUNCTION, PLAYER DESC STUFF, PREGNANCY
+// COMPLETE
     AmilyScene.amilyHermOnFemalePC = function () {
 
         clearOutput();
-        outputText("Amily's efforts at leading you to a place to make love are a bit hampered by the erection tenting her pants, which she is clearly still having a bit of difficulty adjusting to. Finally, though, you have reached her current den, where you waste no time in removing your " + player.armorName + ".<br><br>");
+        outputText("Amily's efforts at leading you to a place to make love are a bit hampered by the erection tenting her pants, which she is clearly still having a bit of difficulty adjusting to. Finally, though, you have reached her current den, where you waste no time in removing your " + player.armor.equipmentName + ".<br><br>");
+
+        //" + player.chestDesc() + "
 
         if (gameFlags[AMILY_HERM_TIMES_FUCKED_BY_FEMPC] == 0) outputText("\"<i>I can't believe this is actually happening... I've grown a cock and I'm about to use it on another woman.</i>\" Amily mutters to herself, though it's very evident that she likes what she sees, unable to resist staring at your " + player.chestDesc() + " or your " + player.vaginaDescript() + ".<br><br>");
         else outputText("\"<i>I still can't believe that I'm burying this hot, throbbing thing in another woman's pussy... More than that, I think I'm actually starting to like it.</i>\" Amily comments to herself, staring unabashedly at your curves.<br><br>");
@@ -2586,7 +2601,7 @@ AmilyScene.start = function () {
         }
 
         outputText("You smile at her, and indicate that she may want to remove her own clothing. Looking a bit embarrassed, Amily strips herself down, revealing her perky breasts and her straining, eager cock for your own perusal. You step close and reach out to gently stroke the hot, pulsing member, eliciting a pleased groan from the futanari mouse, which entices you to use your grip around it to lead her to the makeshift bed, where you sink down onto your back and spread your ");
-        // Something is Fishy about this choice. I think it was a placeholder.
+        // Something is Fishy about this choice. I think it was a placeholder. Note bracketed entry in else.
         if (player.isBiped()) outputText(player.legs() + " in readiness for her.");
         else outputText(" [cunt] in readiness for her.");
 
@@ -2597,8 +2612,8 @@ AmilyScene.start = function () {
         else outputText("Amily grips your " + player.hipDescript() + ", gathering her courage, and then plunges her penis into your depths. Cautiously at first, she begins to thrust herself back and forth, growing faster and harder as her resolve builds.");
 
         // UNCOMMENT WHEN cuntChange function is complete in Creature.js
-        //player.cuntChange((gameFlags[AMILY_WANG_LENGTH] * gameFlags[AMILY_WANG_GIRTH]), true, true, false);
-        //outputText("<br><br>");
+        player.cuntChange((gameFlags[AMILY_WANG_LENGTH] * gameFlags[AMILY_WANG_GIRTH]), true, true, false);
+        outputText("<br><br>");
 
         //CHECK ODD IF THEN IN TEXT
         outputText("Amily's ministrations are hardly the most expert of sexual techniques you've seen in Mareth, but her intentions to make it as pleasant as possible for you are obvious, and what she lacks in expertise she makes up for in enthusiasm, " + ((gameFlags[AMILY_NOT_FURRY] == 0) ? "squeaking" : "panting") + " and moaning as the unfamiliar sensations of your " + player.vaginaDescript() + " gripping her newfound penis fill her. You work your hardest to make it good as well, but Amily's inexperience with having a male sexual organ is evident in that she soon loses control and, with a loud " + ((gameFlags[AMILY_NOT_FURRY] == 0) ? "squeak" : "groan") + ", you feel her shooting cum into your thirsty " + player.vaginaDescript() + ". The hot fluid gushes from her futa-member, and when the last few drops have dripped from her, she collapses onto you, panting.<br><br>");
@@ -2610,9 +2625,9 @@ AmilyScene.start = function () {
         outputText("You smile and reach up to stroke her cheek. She smiles back and reaches down to pat you on your belly.");
 
         //(If player is preg
-        /*
-         if (player.isPregnant()) {
-         if (player.pregnancyType == PregnancyStore.PREGNANCY_AMILY)
+
+        if (playerPregnancy.isPregnant()) {
+            if (playerPregnancy.pregnancyTypeFlag == "Amily")
          outputText("\"<i>Boy, this is weird.  I'm a woman and I'm going to be a dad.");
          else outputText("\"<i>After you give birth to this baby come and see me when you're ready for mine.  This is really weird, I'm a woman and I can't wait to be a dad.");
          }
@@ -2620,9 +2635,9 @@ AmilyScene.start = function () {
          else {
          outputText("\"<i>Let's see if you'll be a mommy from this load... If not, well, I guess we'll have to try again.");
          //PREGGO CHECK HERE
-         player.knockUp(PregnancyStore.PREGNANCY_AMILY, PregnancyStore.INCUBATION_MOUSE);
+         playerPregnancy.knockUp(PREGNANCY_AMILY, INCUBATION_MOUSE);
          }
-         */
+
         outputText("</i>\"  Chuckling softly, you lay there and embrace your lover for a time and then, reluctantly, you get dressed and leave.");
         player.orgasm();
         gameFlags[AMILY_HERM_TIMES_FUCKED_BY_FEMPC]++;
@@ -2638,14 +2653,14 @@ AmilyScene.start = function () {
 
 
 
-//Having sex with Amily for the first time - NEED SPRITE, PLAYER VARS
+//Having sex with Amily for the first time - COMPLETE
     AmilyScene.amilySexFirstTime = function () {
         clearOutput();
 
         outputText("Amily leads you on a convulated route through the ruins of the village. Up streets, down streets, around corners, even straight through some ruins. ");
         //(If player is five feet or less in height:
-        //if (player.tallness < 60) outputText("Fortunately, being smaller than average means you have less difficulty following her than you might.");
-        // else if (player.tallness >= 84) outputText("Your considerable size makes it surprisingly tricky to get around, but you manage to stay with her.");
+        if (player.tallness < 60) outputText("Fortunately, being smaller than average means you have less difficulty following her than you might.");
+        else if (player.tallness >= 84) outputText("Your considerable size makes it surprisingly tricky to get around, but you manage to stay with her.");
         outputText("  Finally, you are led into one particular ruined house, and from there, to a bedroom. It's not exactly an impressive sight; a few bits of smashed furniture, and a large mound of vaguely clean rags and tattered cushions is the closest thing to a bed. The floor is covered in a thick layer of dirt - more than just dust, it's like dirt was deliberately brought in from outside.<br><br>");
         outputText("Amily sees you examining the room and looks sheepish. \"<i>I have to stay hidden, I can't afford to make it too obvious that anyone lives here. That dirt actually helps warn me if anyone else has found this bolthole.</i>\" She idly takes her tail in one hand and starts stroking the tip. \"<i>So... here we are?</i>\" She says, hesitantly. It's clear that for all her insistence on this being what she needed to do, she's evidently a virgin, and has no real idea of how to proceed from here. What do you do?<br><br>");
 
@@ -2658,7 +2673,7 @@ AmilyScene.start = function () {
     };
 
 
-// "Take charge" (i.e be a total douche) during first sexual encounter with Amily - NEED SPRITE, COCK VARS
+// "Take charge" (i.e be a total douche) during first sexual encounter with Amily - NEED COCK VARS? NEED TO TEST THE TRANSFORMATIONS
     AmilyScene.amilySexFirstTimeTakeCharge = function () {
         clearOutput();
         //outputText(images.showImage("amily-forest-takecharge"), false);
@@ -2712,7 +2727,8 @@ AmilyScene.start = function () {
         AmilyScene.amilyPreggoChance();
         doNext(Camp.returnToCampUseOneHour);
     };
-// Wait for Amily to make the first move during first sexual encounter. - NEED SPRITE, PLAYER COCK VARS
+
+// Wait for Amily to make the first move during first sexual encounter. - COMPLETE
     AmilyScene.amilySexFirstTimeHesitate = function () {
         clearOutput();
         //outputText(images.showImage("amily-forest-plainfuck"), false);
@@ -2736,7 +2752,7 @@ AmilyScene.start = function () {
 
     };
 
-// Kiss Amily first before going further during first sexual encounter -- NEED SPRITE
+// Kiss Amily first before going further during first sexual encounter -- COMPLETE
     AmilyScene.amilySexFirstTimeKiss = function () {
         clearOutput();
 
@@ -2775,11 +2791,11 @@ AmilyScene.start = function () {
     // Amily Pregnancy code and birthing scenes
     //---------
 
-// Pregnancy array for Amily
+// Pregnancy array for Amily - COMPLETE
     AmilyScene.amilyPregnancy = new PregnancyStore.Pregnancy(gameFlags[AMILY_PREGNANCY_TYPE], gameFlags[AMILY_INCUBATION], gameFlags[AMILY_BUTT_PREGNANCY_TYPE], gameFlags[AMILY_OVIPOSITED_COUNTDOWN]);
 
 
-// DONE, surprisingly. But there are other pregnancy functions that are needed.
+// COMPLETE
     AmilyScene.amilyPreggoChance = function () {
         //Is amily a chaste follower?
         if (gameFlags[AMILY_FOLLOWER] == 1) {
@@ -2802,12 +2818,12 @@ AmilyScene.start = function () {
             timeAware.push(AmilyScene.amilyPregnancy);
 
             }
-            //      outputText("Amily got pregnant!");
 
 
-        }
-        ;
 
+        };
+
+// COMPLETE
         AmilyScene.amilyGivesBirth = function () {
             outputText("You head into the ruined village, wondering how Amily is doing. You can't be sure, but you think that it will soon be time for her to give birth. Right as that thought sinks in, you hear a squeaking wail of pain in the distance. You hurriedly take off to find the source, and you soon find her; Amily, squatting naked in the shelter of a building. She squeals softly with exertion as her swollen abdomen visibly ripples, and fluids drip from her swollen pink vagina. She is definitely in labor.<br><br>");
 
@@ -2820,6 +2836,7 @@ AmilyScene.start = function () {
             addButton(2, "Help", AmilyScene.amilyLaborHelp, null, null, null, "Tooltip to be added.");
         };
 
+// COMPLETE
         AmilyScene.amilyLaborLeave = function () {
             clearOutput();
             outputText("You make a hasty retreat. You aren't sure why; maybe it was fear, maybe it was memories of the way the midwives always chased the men away when one of the women back in the village went into labor. Reassuring yourself that she will be fine, you head back to camp.<br><br>");
@@ -2830,7 +2847,7 @@ AmilyScene.start = function () {
             doNext(Camp.returnToCampUseOneHour);
         };
 
-
+// COMPLETE
         //[Watch]
         AmilyScene.amilyLaborWatch = function () {
             clearOutput();
@@ -2855,6 +2872,7 @@ AmilyScene.start = function () {
             doNext(Camp.returnToCampUseOneHour);
         };
 
+// COMPLETE
         AmilyScene.amilyLaborHelp = function () {
             clearOutput();
             outputText("You move forward instinctively. Amily is in labor – she needs help. The fact that you are the father only makes it more natural for you to want to help her.<br><br>");
@@ -2907,15 +2925,13 @@ AmilyScene.start = function () {
         };
 
 
-        /*************
-         *
-         * CORRUPTION PATH
-         *
-         **************/
+//--------------
+// CORRUPTION PATH
+//--------------
 
 //Requires PC have done first meeting and be corrupt - NEED PERK CODE AND A FEW OTHER PLAYER THANGS
-        AmilyScene.meetAmilyAsACorruptAsshat = function () {
-            clearOutput();
+AmilyScene.meetAmilyAsACorruptAsshat = function () {
+   clearOutput();
             outputText("Curious about how Amily is holding up, you head back into the ruined village. This time, you don't bother making any secret of your presence, hoping to attract Amily's attention quicker. After all, she did say that the place is basically empty of anyone except her, and you can handle a measly Imp or Goblin.<br><br>");
             switch (AmilyScene.amilyPregnancy.pregnancyEventCounter) {
                 case 1:
@@ -2970,9 +2986,9 @@ AmilyScene.start = function () {
             //FLAG THAT THIS SHIT WENT DOWN
         };
 
-// COOKING THE POTENT MIXTURE - NEED ITEM CONSUMPTION CODE
-        AmilyScene.cookAmilyASnack = function () {
-            clearOutput();
+// COOKING THE POTENT MIXTURE - COMPLETE
+AmilyScene.cookAmilyASnack = function () {
+    clearOutput();
             //[Cooking the drug - repeat]
             if (gameFlags[CREATE_POTENT_MIXTURE] > 0) {
                 //After raping Amily for the first time, she is commited to the path of corruption.
@@ -3018,9 +3034,9 @@ AmilyScene.start = function () {
                     //CONSUME THE ITEMS AND PUT THE POTENT MIXTURE ITEM INTO KEY ITEM INVENTORY. MAY NEED TO RENAME THAT FLAG.
 
                     //Consume items
-                    //if (player.hasItem(consumables.L_DRAFT)) player.consumeItem(consumables.L_DRAFT);
-                    //else player.consumeItem(consumables.F_DRAFT);
-                    //player.consumeItem(consumables.GOB_ALE);
+                    if (player.hasItem(Items.Consumables.LustDraft)) player.destroyItems(Items.Consumables.LustDraft, 1);
+                    else player.destroyItems(Items.Consumables.FuckDraft, 1);
+                    player.destroyItems(Items.Consumables.GoblinAle, 1);
                     player.createKeyItem(KeyItems.PotentMixture, 0, 0, 0, 0);
                     gameFlags[CREATE_POTENT_MIXTURE]++;
                 }
@@ -3070,10 +3086,9 @@ AmilyScene.start = function () {
                     }
                     outputText("After taking a few minutes to rest you look inside the bowl; the mixture has become pinkish-white in color and it bubbles omniously. You take one of the empty bottles and fill it with as much of the mixture as you can, before putting the cork back and putting it back into your pouch. Now all you have to do is find Amily... You smile wickedly as you head back to camp.<br><br>");
                     //Consume items
-                    /*
-                     if (player.hasItem(consumables.L_DRAFT)) player.consumeItem(consumables.L_DRAFT);
-                     else player.consumeItem(consumables.F_DRAFT);
-                     player.consumeItem(consumables.GOB_ALE);*/
+                    if (player.hasItem(Items.Consumables.LustDraft)) player.destroyItems(Items.Consumables.LustDraft, 1);
+                    else player.destroyItems(Items.Consumables.FuckDraft, 1);
+                    player.destroyItems(Items.Consumables.GoblinAle, 1);
                     player.createKeyItem(KeyItem.PotentMixture, 0, 0, 0, 0);
 
                     gameFlags[CREATE_POTENT_MIXTURE]++;
@@ -3083,11 +3098,8 @@ AmilyScene.start = function () {
             doNext(Camp.returnToCampUseOneHour);
         };
 
-//[Stalking Amily (Corrupt)]
-//This event takes about 3 hours.
-//Only happens if the PC has the Potent Mixture and is >= 25 Corruption.
-
-        AmilyScene.amilyCorrupt1 = function () {
+// COMPLETE
+AmilyScene.amilyCorrupt1 = function () {
             clearOutput();
             outputText("You step into the ruined village and set out to look for Amily.<br><br>");
 
@@ -3115,7 +3127,7 @@ AmilyScene.start = function () {
 
                 outputText("This is your cue to act; you quickly burst out of your hideout and swipe her blowpipe away. Amily jumps away in surprise and reaches for her knife, assuming a fighting stance. You ready your " + player.weapon.equipmentName + " and prepare to teach the foolish mouse a lesson.<br><br>");
                 //[Proceed to battle.]
-                // NEED TO FIGURE OUT COMBAT CODE!
+
                 startCombat(new Amily(), true);
             }
 //(if PC's speed >= 65)
@@ -3127,7 +3139,7 @@ AmilyScene.start = function () {
 
                 outputText("Panicked, she takes her knife and prepares to fight you. You ready your " + player.weapon.equipmentName + " and prepare to teach the foolish mouse a lesson.<br><br>");
                 //[Proceed to battle.]
-                //NEED TO FIGURE OUT COMBAT CODE!
+
                 startCombat(new Amily(), true);
             }
             else {
@@ -3137,8 +3149,8 @@ AmilyScene.start = function () {
         }
 
 
-//[Stalking Amily 2 (Corrupt)]
-        AmilyScene.amilyCorrupt2 = function () {
+//COMPLETE
+AmilyScene.amilyCorrupt2 = function () {
             clearOutput();
 //(if PC is genderless)
             if (player.gender == 0) {
@@ -3173,7 +3185,7 @@ AmilyScene.start = function () {
                     doNext(Camp.returnToCampUseOneHour);
                     return;
                 }
-                outputText("You begin stripping off your " + player.armorName + " and show her your ");
+                outputText("You begin stripping off your " + player.armor.equipmentName + " and show her your ");
                 if (player.hasCock()) {
                     outputText("erect " + player.cockDescript(0));
                     if (player.hasVagina()) outputText(" and ");
@@ -3192,15 +3204,15 @@ AmilyScene.start = function () {
                 outputText("Glad to see she meant you no harm, you decide it's time to reward her for her openness. \"<i>Now open wide once more, Amily. It's time for your reward.</i>\" you tell her.<br><br>");
 
                 outputText("\"<i>Yes! Please I need it!</i>\" she says eagerly, closing her eyes and opening her mouth.");
-                //REMOVE POTENT MIXTURE. NEED TO PROGRAM KEY ITEM CODE
+
                 player.removeKeyItem(KeyItems.PotentMixture);
                 //RAPE 2 GO
-                AmilyScene.amilyCorruptionRape(); //chooseYourAmilyRape();
+                AmilyScene.amilyCorruptionRape();
             }
         }
 
-//[Stalking Amily 3 (Corrupt)]
-        AmilyScene.amilyCorrupt3 = function () {
+//COMPLETE
+AmilyScene.amilyCorrupt3 = function () {
             clearOutput();
 //(if PC is genderless)
             if (player.gender == 0) {
@@ -3240,8 +3252,8 @@ AmilyScene.start = function () {
             AmilyScene.amilyCorruptionRape(); //chooseYourAmilyRape();
         }
 
-        AmilyScene.amilyCorruptionRape = function () {
-            outputText("Reached Corruption Rape Chooser. Placeholder.");
+//COMPLETE
+AmilyScene.amilyCorruptionRape = function () {
 
             if (gameFlags[AMILY_CORRUPTION_PATH] == 0) {
                 doNext(AmilyScene.rapeCorruptAmily1);
@@ -3274,7 +3286,8 @@ AmilyScene.start = function () {
             }
         }
 
-        AmilyScene.rapeCorruptAmily1 = function () {
+//OMPLETE
+AmilyScene.rapeCorruptAmily1 = function () {
             gameFlags[AMILY_CORRUPTION_PATH]++;
             clearOutput();
             //[Raping Amily]
@@ -3321,8 +3334,8 @@ AmilyScene.start = function () {
             else doNext(AmilyScene.rapeCorruptAmily1Female);
         }
 
-//[Male Amily Rape First Time]
-        AmilyScene.rapeCorruptAmily1Male = function () {
+//COMPLETE
+AmilyScene.rapeCorruptAmily1Male = function () {
             var x = player.cockThatFits(61);
             if (x < 0) x = 0;
             player.removeKeyItem(KeyItems.PotentMixture);
@@ -3340,14 +3353,14 @@ AmilyScene.start = function () {
             player.orgasm();
             player.modStats("lib", -2);
             player.modStats("cor", 5);
-            //NEED COMBAT CODE!
-            //if (getGame().inCombat) combat.cleanupAfterCombat();
-            //else
-            doNext(Camp.returnToCampUseOneHour);
+
+            if (inCombat() == true) cleanupAfterCombat();
+            else
+                doNext(Camp.returnToCampUseOneHour);
         }
 
-//[Female]
-        AmilyScene.rapeCorruptAmily1Female = function () {
+//NEED COMBAT CODE
+AmilyScene.rapeCorruptAmily1Female = function () {
             clearOutput();
             player.removeKeyItem(KeyItems.PotentMixture);
             outputText("You smile and say, \"<i>Fine, but you're gonna have to work for it.</i>\" Amily's answer is to open her mouth wide. The invitation clear, you advance and lower your " + player.vaginaDescript() + " towards her open mouth.<br><br>");
@@ -3382,13 +3395,12 @@ AmilyScene.start = function () {
             player.orgasm();
             player.modStats("lib", -2);
             player.modStats("cor", 5);
-            //NEED COMBAT CODE
-//if (getGame().inCombat) combat.cleanupAfterCombat();
-//else
-            doNext(Camp.returnToCampUseOneHour);
+            if (inCombat() == true) cleanupAfterCombat();
+            else
+                doNext(Camp.returnToCampUseOneHour);
         }
 
-        AmilyScene.rapeCorruptAmily2Male = function () {
+AmilyScene.rapeCorruptAmily2Male = function () {
             clearOutput();
             var x = player.cockThatFits(61);
             if (x < 0) x = 0;
@@ -3438,8 +3450,8 @@ AmilyScene.start = function () {
             AmilyScene.rapeCorruptAmily2Epilogue();
         }
 
-//[Female]
-        AmilyScene.rapeCorruptAmily2Female = function () {
+//COMPLETE
+AmilyScene.rapeCorruptAmily2Female = function () {
 
             clearOutput();
             outputText("You roughly grab ahold of Amily's ears and shove her face on your " + player.vaginaDescript() + ".");
@@ -3470,7 +3482,8 @@ AmilyScene.start = function () {
             AmilyScene.rapeCorruptAmily2Epilogue();
         }
 
-        AmilyScene.rapeCorruptAmily2Epilogue = function () {
+// COMPLETE
+AmilyScene.rapeCorruptAmily2Epilogue = function () {
             gameFlags[AMILY_CORRUPTION_PATH]++;
 //Both variations link into this next paragraph
             outputText("Amily falls on her back, panting happily and licking her mouth to taste as much of you as possible. That's when you notice her beginning to change, slowly but significantly.<br><br>");
@@ -3486,7 +3499,8 @@ AmilyScene.start = function () {
             doNext(Camp.returnToCampUseOneHour);
         }
 
-        AmilyScene.rapeCorruptAmily3Male = function () {
+// COMPLETE
+AmilyScene.rapeCorruptAmily3Male = function () {
             clearOutput();
             outputText("You strip while Amily watches hungrily. Finally naked, you order the mouse to come closer and use her breasts to pleasure you. Amily quickly scoots closer on her knees and press her breasts around your " + player.cockDescript(0) + ".");
 //[(if PC is huge)
@@ -3538,7 +3552,8 @@ AmilyScene.start = function () {
             AmilyScene.rapeCorruptAmily3Epilogue();
         }
 
-        AmilyScene.rapeCorruptAmily3Female = function () {
+// COMPLETE
+AmilyScene.rapeCorruptAmily3Female = function () {
             clearOutput();
             outputText("You strip while Amily watches hungrily.  Finally naked, you order the mouse to come closer and use her breasts to pleasure you. Amily scoots closer on her knees and presses her breasts against your " + player.vaginaDescript() + ", one orb at a time. You smile and moan softly as her erect nipple stimulates your labia; ");
             //[(if PC is a squirter)
@@ -3578,11 +3593,11 @@ AmilyScene.start = function () {
             outputText("<br><br>");
 
 //Link to followup.
-            AmilyScene.rapeCorruptAmily3Epilogue();
+AmilyScene.rapeCorruptAmily3Epilogue();
         }
 
-//Both variants link here
-        AmilyScene.rapeCorruptAmily3Epilogue = function () {
+//COMPLETE
+AmilyScene.rapeCorruptAmily3Epilogue = function () {
             gameFlags[AMILY_CORRUPTION_PATH]++;
             outputText("Amily falls on her back, licking her lips and rubbing her bulging belly. Then she begins moaning as something starts changing. Her tail thrashes madly between her legs, and you watch enraptured as a spade-like tip forms on the tip of her tail. On top of her head a pair of small bumps appear, then develop into small cute demonic horns... Just like you imagined. Could it be that the true source of Amily's transformation was you, and not the mixture?<br><br>");
 
@@ -3605,7 +3620,8 @@ AmilyScene.start = function () {
             doNext(Camp.returnToCampUseOneHour);
         }
 
-        AmilyScene.rapeCorruptAmily4Meeting = function () {
+// COMPLETE
+AmilyScene.rapeCorruptAmily4Meeting = function () {
             clearOutput();
 //(if PC is genderless)
             if (player.gender == 0) {
@@ -3631,11 +3647,11 @@ AmilyScene.start = function () {
             else doNext(AmilyScene.rapeCorruptAmily4Male);
         }
 
-//[Male]
-        AmilyScene.rapeCorruptAmily4Male = function () {
+//COMPLETE
+AmilyScene.rapeCorruptAmily4Male = function () {
 
             clearOutput();
-            outputText("You slowly strip off your " + player.armorName + ", while Amily pants in anticipation. When you're done you present to her your erect " + player.cockDescript(0) + "; she quickly nuzzles and kisses along your length, rubbing her breasts along your length");
+            outputText("You slowly strip off your " + player.armor.equipmentName + ", while Amily pants in anticipation. When you're done you present to her your erect " + player.cockDescript(0) + "; she quickly nuzzles and kisses along your length, rubbing her breasts along your length");
 //[(if pc has balls)
             if (player.balls > 0) outputText(" and " + player.ballsDescriptLight());
             outputText(".<br><br>");
@@ -3713,11 +3729,11 @@ AmilyScene.start = function () {
             AmilyScene.rapeCorruptAmily4Epilogue();
         }
 
-//[Female]
-        AmilyScene.rapeCorruptAmily4Female = function () {
+//COMPLETE
+AmilyScene.rapeCorruptAmily4Female = function () {
 
             clearOutput();
-            outputText("You slowly strip off your " + player.armorName + ", while Amily pants in anticipation. When you're done you present to her your dripping " + player.vaginaDescript() + "; she quickly nuzzles and kisses your clit.");
+            outputText("You slowly strip off your " + player.armor.equipmentName + ", while Amily pants in anticipation. When you're done you present to her your dripping " + player.vaginaDescript() + "; she quickly nuzzles and kisses your clit.");
 //[(if PC has balls)
             if (player.balls > 0) outputText("  Pulling back enough to give your balls a teasing lick.");
             outputText("<br><br>");
@@ -3792,8 +3808,8 @@ AmilyScene.start = function () {
             AmilyScene.rapeCorruptAmily4Epilogue();
         }
 
-//Both variations link here.
-        AmilyScene.rapeCorruptAmily4Epilogue = function () {
+//ADD AMILY APPEARANCE FLAGS. CHECK PURE PATH ON THIS AS WELL. WILL ALSO HAVE A FEW FOLLOWER CHECKS TO ADD AS WELL.
+AmilyScene.rapeCorruptAmily4Epilogue = function () {
             outputText("Your cum is completely absorbed by her and she doubles over in pleasure as she screams. Her biggest orgasm yet rocks her to the core; her eyes roll back and you see her begin to change.<br><br>");
             outputText("Her " + ((gameFlags[AMILY_NOT_FURRY] == 0) ? "fur turns to a lewd purple" : "hair turns into a lewd purple, skin fading to a light lavender") + "; her small horns grow and become more defined; small bat-like wing sprout from her shoulders; the spade-like tip of her tail grows bigger and more defined; ");
             if (gameFlags[AMILY_NOT_FURRY] == 0)
@@ -3837,26 +3853,31 @@ AmilyScene.start = function () {
 // Amily Human Transformation
 //--------
 
-        AmilyScene.amilyCanHaveTFNow = function () {
-            if (gameFlags[AMILY_NOT_FURRY] == 0 && gameFlags[AMILY_OFFERED_DEFURRY] == 1 && player.hasItem(Items.Consumables.GoldenSeed) && (player.hasItem(Items.Consumables.LBlackEgg) || player.hasItem(Items.Consumables.BlackEgg)) && (player.hasItem(Items.Consumables.SuccubiMilkPurified) || (AmilyScene.amilyCorrupt() == true && player.hasItem(Items.Consumables.SuccubiMilk))) == true) {
+// GAME NOT LIKING THIS FUNCTION FOR SOME REASON!
+AmilyScene.amilyCanHaveTFNow = function () {
+    if (gameFlags[AMILY_NOT_FURRY] == 0 &&
+        gameFlags[AMILY_OFFERED_DEFURRY] == 1 &&
+        player.hasItem(Items.Consumables.GoldenSeed) &&
+        (player.hasItem(Items.Consumables.LBlackEgg) || player.hasItem(Items.Consumables.BlackEgg)) &&
+        (player.hasItem(Items.Consumables.SuccubiMilkPurified) || (AmilyScene.amilyCorrupt() == true && player.hasItem(Items.Consumables.SuccubiMilk))) == true) {
                 return true;
             }
             else return false;
         };
 
-// NEEDS ITEM CONSUMPTION CODE!
+// COMPLETE
 // Arrive with all the stuff you need to make Amily not look completely rediculous.
-        AmilyScene.amilyDefurrify = function () {
+AmilyScene.amilyDefurrify = function () {
             // Figure out how to consume items
-            /*
-             player.consumeItem(consumables.GLDSEED);
-             if (player.hasItem(consumables.BLACKEG)) player.consumeItem(consumables.BLACKEG);
-             else player.consumeItem(consumables.L_BLKEG);
-             if (amilyCorrupt()) {
-             if (player.hasItem(consumables.SUCMILK)) player.consumeItem(consumables.SUCMILK);
-             else player.consumeItem(consumables.P_S_MLK);
+
+             player.destroyItems(Items.Consumables.GoldenSeed, 1);
+             if (player.hasItem(Items.Consumables.BlackEgg)) player.destroyItems(Items.Consumables.BlackEgg, 1);
+             else player.destroyItems(Items.Consumables.LBlackEgg, 1);
+             if (AmilyScene.amilyCorrupt()) {
+             if (player.hasItem(Items.Consumables.SuccubiMilk)) player.destroyItems(Items.Consumables.SuccubiMilk, 1);
+             else player.destroyItems(Items.Consumables.SuccubiMilkPurified);
              }
-             else player.consumeItem(consumables.P_S_MLK); */
+             else player.destroyItems(Items.Consumables.SuccubiMilkPurified);
             gameFlags[AMILY_OFFERED_DEFURRY] = 2; // We're now completing this dumb little quest.
             gameFlags[AMILY_NOT_FURRY] = 1;
             gameFlags[AMILY_OFFER_ACCEPTED] = 1;
@@ -3876,7 +3897,7 @@ AmilyScene.start = function () {
 
         // Bad ending happens when there's five litters and affection is below 40.
         // FIX [MEN] REFERENCE IN THIS BLOCK OF CODE
-        AmilyScene.amilyBadEnding = function () {
+AmilyScene.amilyBadEnding = function () {
             clearOutput();
             outputText("You wander through the empty streets of the ruined village, wondering where Amily is. For all her many faults, she's an acceptable fuck. The sudden sound of footsteps catches your attention, and you ready yourself for battle; Amily never makes her presence felt so clumsily.<br><br>");
             outputText("Except for today. Amily walks out to confront you casually. \"<i>Ah, " + player.name + ", there you are,</i>\" she states. \"<i>Good. I was hoping to see you one last time; I thought you at least deserved a goodbye.</i>\"<br><br>");
@@ -3896,7 +3917,8 @@ AmilyScene.start = function () {
 
 
         //Have over five litters and affection is 40 or higher
-        AmilyScene.amilyBecomesFollower = function () {
+//ADD AMILY APPEARANCE VARIABLES, MARBLE FREAKOUT CODE
+AmilyScene.amilyBecomesFollower = function () {
             clearOutput();
             outputText("As you wander through the empty streets of the ruined village, you wonder where Amily is. Even beyond what she means to you now, you simply enjoy knowing that there's someone else in this twisted place you can talk to.<br><br>");
             outputText("\"<i>" + player.name + "! Darling! You're here!</i>\"<br><br>");
@@ -3956,7 +3978,7 @@ AmilyScene.start = function () {
 
 
 
-/* Holding comment for stuff from the original CoC code
+/* Holding comment for stuff from the original CoC code. Note the timeAwareClass code when we get to implementing Amily in camp.
 
 
  CoC.timeAwareClassAdd(this);

--- a/js/scenes/npcs/amily.js
+++ b/js/scenes/npcs/amily.js
@@ -28,14 +28,11 @@ Upgrade - First time Amily Lesbian scene works well, but the code immediately ha
 
 Upgrade - Lesbian sex and herm sex with Amily doesn't increase her affection at all. I feel this should be changed.
 
+Upgrade and Integrate - Amily Freakout Events for other followers. The paths need to be standardized. Will do when doing camp Amily.
 
- Test - Player Pregnancy with Amily
-
- Test - Check gender flag checking. Gender switching convos need to be checked. Need to make a gender change scene debugging thing in the Camp code.
+Test - Check gender flag checking. Gender switching convos need to be checked. Need to make a gender change scene debugging thing in the Camp code.
 
  Test - Defurring Code
-
-Fix Appearance flags for the endings
 
  Fix all tooltip entries (low priority)
 
@@ -2636,6 +2633,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
          outputText("\"<i>Let's see if you'll be a mommy from this load... If not, well, I guess we'll have to try again.");
          //PREGGO CHECK HERE
          playerPregnancy.knockUp(PREGNANCY_AMILY, INCUBATION_MOUSE);
+         playerPregnancy.eventFill(INCUBATION_MOUSE_EVENT);
          }
 
         outputText("</i>\"  Chuckling softly, you lay there and embrace your lover for a time and then, reluctantly, you get dressed and leave.");
@@ -2813,7 +2811,7 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
 
         //25% + gradually increasing cumQ bonus
         if (rand(4) == 0 || player.cumQ() > rand(1000)) {
-            AmilyScene.amilyPregnancy.eventFill([150, 120, 100, 96, 90, 72, 48]);
+            AmilyScene.amilyPregnancy.eventFill(INCUBATION_AMILY_EVENT);
             AmilyScene.amilyPregnancy.knockUpForce(PREGNANCY_PLAYER, INCUBATION_MOUSE - 182);
             timeAware.push(AmilyScene.amilyPregnancy);
 
@@ -2848,7 +2846,6 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
         };
 
 // COMPLETE
-        //[Watch]
         AmilyScene.amilyLaborWatch = function () {
             clearOutput();
 
@@ -2923,6 +2920,114 @@ AmilyScene.determineAmilySexEvent = function () { // May need to force a false b
             gameFlags[AMILY_AFFECTION] += 5;
             doNext(Camp.returnToCampUseOneHour);
         };
+
+//Player gives Birth (quest version): UPDATE WHEN WE WORK ON AMILY IN CAMP!
+AmilyScene.pcBirthsAmilysKidsQuestVersion = function() {
+    gameFlags[PC_TIMES_BIRTHED_AMILYKIDS]++;
+    //In camp version:
+    //    if (flags[kFLAGS.AMILY_FOLLOWER] == 1) {
+    //playerBirthsWifAmilyMiceInCamp();
+    //return;
+    //}
+//Quest Ending: Herm Amily Variant
+//Requirements: Player must have given birth to a litter of Amily's children at least five times before.
+    if (gameFlags[PC_TIMES_BIRTHED_AMILYKIDS] + gameFlags[AMILY_BIRTH_TOTAL] >= 5) {
+        outputText("You wake up suddenly to strong pains and pressures in your gut. As your eyes shoot wide open, you look down to see your belly absurdly full and distended. You can feel movement underneath the skin, and watch as it is pushed out in many places, roiling and squirming in disturbing ways. The feelings you get from inside are just as disconcerting. You count not one, but many little things moving around inside you. There are so many, you can't keep track of them.<br><br>");
+
+        outputText("Pain shoots through you as they pull open your cervix forcefully, causing you to cry out involuntarily. At once, Amily suddenly appears, racing out from the undergrowth. \"<i>Is it time? Are you going into labor?</i>\" She asks, worry evident in her voice. Your pain is momentarily forgotten by your surprise and you ask where she came from. She snorts disdainfully at the question. \"<i>I've been shadowing you for a couple of days, now. Did you really think I'd let the mother of my children go through this alone?</i>\"<br><br>");
+
+        outputText("Any reply you may have been inclined to make to that is swallowed by another cry of pain as yet another contraction wrings its way through you. Amily takes your hand in hers and you cling to the lifeline of comfort it offers, thankful to not be alone for this. You can feel the first child moving out of your womb, through your cervix, down and into your " + player.vaginaDescript() + ". Your lips part and, with a grunt, you expel the first child into Amily's waiting hand. She holds it up to you so that you can see your firstborn; it's a little mouselet");
+    //(if player is female: 1 in 3 chance of it being boy, girl or herm, if player is herm, 100% chance of it being a herm)"
+    outputText(((gameFlags[AMILY_NOT_FURRY]==0)?", naked, pink, and totally hairless":"") + ". Amily helps hold it to your " + player.breastDescript(0) + ", where it eagerly takes hold of your " + player.nippleDescript(0) + " and starts to suckle. As it drinks, it starts to grow larger, and " + ((gameFlags[AMILY_NOT_FURRY]==0)?"fur the same color as your own hair starts to cover its body":"") +". It quickly drinks its fill and then detaches, its 'father' putting it aside, which is good, because by this time there's another baby waiting for its turn... and another... and another...<br><br>");
+
+    outputText("Soon, you are back to your old self again, lying down in exhaustion with Amily sitting nearby, your many rambunctious offspring already starting to walk and play around you.<br><br>");
+
+    outputText("\"<i>Get some rest, darling. There are things you and I need to talk about,</i>\" Amily instructs you.<br><br>");
+
+    outputText("You are eager to comply, though your last thought as you sink into unconsciousness is to wonder what Amily wants to talk about.");
+        gameFlags[PC_TIMES_BIRTHED_AMILYKIDS]++;
+        playerPregnancy.knockUpForce(0,0); // May not need this
+    //To part 2!
+    doNext(AmilyScene.postBirthingEndChoices);
+    return;
+}
+    outputText("You wake up suddenly to strong pains and pressures in your gut. As your eyes shoot wide open, you look down to see your belly absurdly full and distended. You can feel movement underneath the skin, and watch as it is pushed out in many places, roiling and squirming in disturbing ways. The feelings you get from inside are just as disconcerting. You count not one, but many little things moving around inside you. There are so many, you can't keep track of them.<br><br>");
+
+outputText("Pain shoots through you as they pull open your cervix forcefully, causing you to cry out involuntarily. At once, Amily suddenly appears, racing out from the undergrowth. \"<i>Is it time? Are you going into labor?</i>\" She asks, worry evident in her voice. Your pain is momentarily forgotten by your surprise and you ask where she came from. She snorts disdainfully at the question. \"<i>I've been shadowing you for a couple of days, now. Did you really think I'd let the mother of my children go through this alone?</i>\"<br><br>");
+
+outputText("Any reply you may have been inclined to make to that is swallowed by another cry of pain as yet another contraction wrings its way through you. Amily takes your hand in hers and you cling to the lifeline of comfort it offers, thankful to not be alone for this. You can feel the first child moving out of your womb, through your cervix, down and into your " + player.vaginaDescript() + ". Your lips part and, with a grunt, you expel the first child into Amily's waiting hand. She holds it up to you so that you can see your firstborn; it's a little mouselet", false);
+//(if player is female: 1 in 3 chance of it being boy, girl or herm, if player is herm, 100% chance of it being a herm)
+outputText(((gameFlags[AMILY_NOT_FURRY]==0)?", naked, pink, and totally hairless":"") +". Amily helps hold it to your " + player.chestDesc() + ", where it eagerly takes hold of your " + player.nippleDescript(0) + " and starts to suckle. As it drinks, it starts to grow larger, and "+((gameFlags[AMILY_NOT_FURRY]==0)?"fur the same color as your own hair starts to cover its body":"") +". It quickly drinks its fill and then detaches, its 'father' putting it aside, which is good, because by this time there's another baby waiting for its turn... and another... and another...<br><br>");
+
+outputText("Soon, you are back to your old self again, lying down in exhaustion with Amily sitting nearby, your many rambunctious offspring already starting to walk and play around you.<br><br>");
+
+outputText("\"<i>Look at them all. You... I never thought it would turn out this way, but you're helping my dream to come true. Thank you,</i>\" Amily tells you sincerely. You're too exhausted to keep your eyes open for long, but she promises to stay in touch and, even as you fall asleep, she's gathering up your children and taking them away.");
+    playerPregnancy.knockUpForce(0,0); // May not need this
+};
+
+AmilyScene.postBirthingEndChoices = function() {
+    clearOutput();
+    outputText("When you awake, the children are gone, and Amily has prepared something for you to eat. You eagerly start to feed yourself as Amily, looking grave, begins to speak.<br><br>");
+
+    outputText("\"<i>You know that this... well, this isn't how I saw my future going. I wanted a human mate to help me make pure children, to revive my race, that's true, but... I kind of always saw myself as the mother to those children. But, being the father... well, it's not so bad.</i>\" She takes your hands in hers, looking deep into your eyes. \"<i>I... I never dreamed I'd say this to ");
+//(if player is female:
+    if (player.gender == 2) outputText("another woman");
+//, if player is herm:
+    else outputText("a hermaphrodite");
+    outputText(", but... I love you. The children, they're going to leave here now, and set up a new village somewhere else. But I... I want to stay here with you. Forever. Please, say yes.</i>\"<br><br>");
+    outputText("Do you accept her offer?");
+    gameFlags[PC_TIMES_BIRTHED_AMILYKIDS]++;
+    menu();
+    addButton(0, "Accept", AmilyScene.acceptAmilyHermPath, null, null, null, "TO BE ADDED");
+    addButton(1, "Stay Friends", AmilyScene.declineAmilyHermPath, null, null, null, "TO BE ADDED");
+    addButton(2, "Shoot Down", AmilyScene.rejectAmilyHermPath, null, null, null, "TO BE ADDED");
+    
+}
+
+
+AmilyScene.acceptAmilyHermPath = function() {
+    clearOutput();
+    outputText("You stare at her in surprise. Then, you take hold of her hands and smile at her. You tell her that nothing would make you happier than to have her here, living with you, being with her. Amily squeaks loudly with joy and passionately embraces you, kissing you as deeply as she can. When she finally lets you go for lack of air, she takes a good long look around the camp, as if she's seeing it for the first time.<br><br>");
+
+    outputText("\"<i>Well, I better start moving in, huh?</i>\" she jokes. She then flops down on your sleeping roll beside you, \"<i>There we are, I'm moved in.</i>\" She grins at you, and you can't help but laugh.<br><br>");
+
+    //(Amily becomes a follower; quest is over)
+    //Disable village encounters!
+    gameFlags[AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
+//Set amily follower flag
+    gameFlags[AMILY_FOLLOWER] = 1;
+    gameFlags[AMILY_CUP_SIZE] = 1;
+    gameFlags[AMILY_NIPPLE_LENGTH] = .3;
+    gameFlags[AMILY_HIP_RATING] = 6;
+    gameFlags[AMILY_ASS_SIZE] = 6;
+    gameFlags[AMILY_VAGINAL_WETNESS] = 1;
+
+    gameFlags[AMILY_CLOTHING] = "rags";
+    doNext(playerMenu); // Check this.
+}
+
+//[=Stay Friends=]
+AmilyScene.declineAmilyHermPath = function() {
+    clearOutput();
+    outputText("You think about it, and then shake your head. You tell her that you do appreciate her feelings, but you're not sure the two of you are ready to make the committment that living together entails. Besides, your camp is set up to guard the portal leading back to your world; that makes it a magnet for demons. You can't imagine exposing her to the danger that moving to camp would entail for her.<br><br>");
+
+outputText("Amily doesn't look entirely happy, but you assure her that you will keep coming back to see her. And when you tease at the possibility of a few more litters in your respective futures, stroking her penis through her tattered pants, she blushes but agrees to go.<br><br>");
+    //(Amily returns to the Ruined Village; this scene will repeat the next time the player gives birth to a litter of Amily's children)
+    doNext(playerMenu); // Check this
+}
+
+//Shoot the bitch down!
+AmilyScene.rejectAmilyHermPath = function() {
+
+clearOutput();
+outputText("You stare at her coldly, and inform her that you have no interest in any kind of relationship with her on that level. You decided to let her plant her brats in you out of pity, but now that she no longer needs your womb, you have no more intention of renting it out to her.<br><br>");
+
+outputText("Amily reels, heartstruck, her expression making it clear that her heart has shattered, tears rolling down her face. \"<i>I...I didn't know that was the way you felt about me. F-Fine, if that's how it is...</i>\" She bursts into sobs and runs away; you know she'll never come back.<br><br>");
+//Disable village encounters, go!
+    gameFlags[AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
+    doNext(playerMenu);
+}
+
 
 
 //--------------
@@ -3808,7 +3913,7 @@ AmilyScene.rapeCorruptAmily4Female = function () {
             AmilyScene.rapeCorruptAmily4Epilogue();
         }
 
-//ADD AMILY APPEARANCE FLAGS. CHECK PURE PATH ON THIS AS WELL. WILL ALSO HAVE A FEW FOLLOWER CHECKS TO ADD AS WELL.
+//NEED MARBLE TO FINISH
 AmilyScene.rapeCorruptAmily4Epilogue = function () {
             outputText("Your cum is completely absorbed by her and she doubles over in pleasure as she screams. Her biggest orgasm yet rocks her to the core; her eyes roll back and you see her begin to change.<br><br>");
             outputText("Her " + ((gameFlags[AMILY_NOT_FURRY] == 0) ? "fur turns to a lewd purple" : "hair turns into a lewd purple, skin fading to a light lavender") + "; her small horns grow and become more defined; small bat-like wing sprout from her shoulders; the spade-like tip of her tail grows bigger and more defined; ");
@@ -3825,18 +3930,18 @@ AmilyScene.rapeCorruptAmily4Epilogue = function () {
             outputText("<b>(Corrupted Amily added to slaves)</b>");
 //Add corrupted amily flag here
             gameFlags[AMILY_FOLLOWER] = 2;
-//ADD THIS LATER
-//if (player.pregnancyType == PregnancyStore.PREGNANCY_AMILY) player.knockUpForce(PregnancyStore.PREGNANCY_MOUSE, player.pregnancyIncubation);
+//Change to normal mouse pregnancy
+            if (playerPregnancy.pregnancyTypeFlag == PREGNANCY_AMILY) playerPregnancy.knockUpForce(PREGNANCY_MOUSE, playerPregnancy.pregnancyIncubationFlag);
 //Set other flags if Amily is moving in for the first time
 //if (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00173] == 0) { //Corruption freakout flag. Not sure if we need to wrap it like this
-            /*
-             flags[kFLAGS.AMILY_CUP_SIZE] = 5;
-             flags[kFLAGS.AMILY_NIPPLE_LENGTH] = .5;
-             flags[kFLAGS.AMILY_HIP_RATING] = 12;
-             flags[kFLAGS.AMILY_ASS_SIZE] = 12;
-             flags[kFLAGS.AMILY_VAGINAL_WETNESS] = 1;
-             flags[kFLAGS.AMILY_CLOTHING] = "sexy rags";
-             //}
+            gameFlags[AMILY_CUP_SIZE] = 5;
+            gameFlags[AMILY_NIPPLE_LENGTH] = .5;
+            gameFlags[AMILY_HIP_RATING] = 12;
+            gameFlags[AMILY_ASS_SIZE] = 12;
+            gameFlags[AMILY_VAGINAL_WETNESS] = 1;
+            gameFlags[AMILY_CLOTHING] = "sexy rags";
+    /*         
+    //}
              //if marble is there, tag it for freakout
              if (player.findStatusEffect(StatusEffects.CampMarble) >= 0) {
              flags[kFLAGS.MARBLE_OR_AMILY_FIRST_FOR_FREAKOUT] = 1;
@@ -3917,7 +4022,7 @@ AmilyScene.amilyBadEnding = function () {
 
 
         //Have over five litters and affection is 40 or higher
-//ADD AMILY APPEARANCE VARIABLES, MARBLE FREAKOUT CODE
+//ADD AMILY APPEARANCE VARIABLES, MARBLE  AND IZMA FREAKOUT CODE
 AmilyScene.amilyBecomesFollower = function () {
             clearOutput();
             outputText("As you wander through the empty streets of the ruined village, you wonder where Amily is. Even beyond what she means to you now, you simply enjoy knowing that there's someone else in this twisted place you can talk to.<br><br>");
@@ -3954,14 +4059,15 @@ AmilyScene.amilyBecomesFollower = function () {
             outputText("<b>Amily has joined you as a lover.</b><br><br>");
             //Set amily follower flag
             gameFlags[AMILY_FOLLOWER] = 1;
-            //flags[kFLAGS.AMILY_CUP_SIZE] = 1;
-            //flags[kFLAGS.AMILY_NIPPLE_LENGTH] = .3;
-            //flags[kFLAGS.AMILY_HIP_RATING] = 6;
-            //flags[kFLAGS.AMILY_ASS_SIZE] = 6;
-            //flags[kFLAGS.AMILY_VAGINAL_WETNESS] = 1;
+            gameFlags[AMILY_CUP_SIZE] = 1;
+            gameFlags[AMILY_NIPPLE_LENGTH] = .3;
+            gameFlags[AMILY_HIP_RATING] = 6;
+            gameFlags[AMILY_ASS_SIZE] = 6;
+            gameFlags[AMILY_VAGINAL_WETNESS] = 1;
 
-            //flags[kFLAGS.AMILY_CLOTHING] = "rags";
+            gameFlags[AMILY_CLOTHING] = "rags";
             //if marble is there, tag it for freakout
+            /*
             //if (player.findStatusEffect(StatusEffects.CampMarble) >= 0) {
             //    flags[kFLAGS.MARBLE_OR_AMILY_FIRST_FOR_FREAKOUT] = 1;
             //}
@@ -3969,7 +4075,7 @@ AmilyScene.amilyBecomesFollower = function () {
             //if Izma is there, tag for freekout!
             //if (flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00238] == 1) {
             //    flags[kFLAGS.UNKNOWN_FLAG_NUMBER_00236] = 1;
-            //}
+            //}*/
             //Disable amily encounters in the village!
             gameFlags[AMILY_VILLAGE_ENCOUNTERS_DISABLED] = 1;
             doNext(Camp.returnToCampUseOneHour);

--- a/js/statusEffectClass.js
+++ b/js/statusEffectClass.js
@@ -1,5 +1,6 @@
 function StatusEffect(type, val1, val2, val3, val4) {
     //Default values
+    if (type == undefined) type = 0; //Fixed now
     if (val1 == undefined) val1 = 0;
     if (val2 == undefined) val2 = 0;
     if (val3 == undefined) val3 = 0;


### PR DESCRIPTION
- Amily combat now works for the Corruption path.
- Amily Appearance flags set for when she's in camp. Follower button not implemented yet
- pregnancyProgression.js added to the game. pregnancyProgression.updatePregnancy() called in the camp code. This is used for player pregnancy events, though the original does a lot more. Many things in that file. Right now, it dumps the messages at the top and then displays the normal camp message. 
- Player can get pregnant from herm Amily and finish the Town Ruins quest that way. Generic mouse pregnancy is not implemented yet. When done so, JoJo/Joy pregnancy will be open for coding.
- Various improvements to pregnancy code. Have more planned to make it simpler to call/check pregnancies.
- Fixed a breast-size function in Appearance.js
- Fixed vagina change functions in Creature.js
- Added new flags. 

TO DO:
- Write debugging menu to help test Amily gender switch freakout code.
- Fix weird bug with Amily defurring route.
- Add tooltip entries to choices throughout.
- Go through code for a final check to mark anything strange or will need implementation later (e.g. Marble/Izma freakouts) before closing this out.
- Implement generic mouse pregnancy

There is a comment block early in Amily.js with suggested updates to the scenario.
